### PR TITLE
Added handler for untagged responses (EXISTS, EXPUNGE, FETCH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,26 @@ multipart/mixed
 }
 ```
 
+## Update notifications
+
+Message updates can be listened for by setting the `onupdate` handler. First argument for the callback defines the update type, and the second one is the new value.
+
+**Example**
+
+```javascript
+client.onupdate = function(type, value){
+    if (type == 'exists') {
+        console.log(value + ' messages exists in selected mailbox');
+    }
+}
+```
+
+Possible types:
+
+  * **exists** is emitted on untagged `EXISTS` response, `value` is the argument number used
+  * **expunge** is emitted on untagged `EXPUNGE` response, `value` is the sequence number of the deleted message
+  * **fetch** is emitted on flag change. `value` includes the parsed message object (probably includes only the sequence number `#` and `flags` array)
+
 ## Close connection
 
 You can close the connection with `close()`. This method doesn't actually terminate the connection, it sends LOGOUT command to the server.

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -141,6 +141,7 @@
     BrowserBox.prototype.onlog = function() {};
     BrowserBox.prototype.onclose = function() {};
     BrowserBox.prototype.onauth = function() {};
+    BrowserBox.prototype.onupdate = function() {};
     /* BrowserBox.prototype.onerror = function(err){}; // not defined by default */
 
     // Event handlers
@@ -751,8 +752,9 @@
      * @param {Function} next Until called, server responses are not processed
      */
     BrowserBox.prototype._untaggedExistsHandler = function(response, next) {
-        console.log('Untagged EXISTS');
-        console.log(response);
+        if (response && response.hasOwnProperty('nr')) {
+            this.onupdate('exists', response.nr);
+        }
         next();
     };
 
@@ -763,8 +765,9 @@
      * @param {Function} next Until called, server responses are not processed
      */
     BrowserBox.prototype._untaggedExpungeHandler = function(response, next) {
-        console.log('Untagged EXPUNGE');
-        console.log(response);
+        if (response && response.hasOwnProperty('nr')) {
+            this.onupdate('expunge', response.nr);
+        }
         next();
     };
 
@@ -775,8 +778,7 @@
      * @param {Function} next Until called, server responses are not processed
      */
     BrowserBox.prototype._untaggedFetchHandler = function(response, next) {
-        console.log('Untagged FETCH');
-        console.log(response);
+        this.onupdate('fetch', [].concat(this._parseFETCH({payload:{FETCH: [response]}}) || []).shift());
         next();
     };
 
@@ -992,6 +994,9 @@
                 break;
             case 'bodystructure':
                 value = this._parseBODYSTRUCTURE([].concat(value || []));
+                break;
+            case 'modseq':
+                value = Number((value.shift() || {}).value) || 0;
                 break;
         }
 

--- a/test/browserbox-unit.js
+++ b/test/browserbox-unit.js
@@ -426,6 +426,42 @@ define(['chai', 'sinon', 'browserbox', './fixtures/mime-torture-bodystructure'],
             });
         });
 
+        describe('untagged updates', function() {
+            it('should receive information about untagged exists', function(done) {
+                br.client._connectionReady = true;
+                br.onupdate = function(type, value){
+                    expect(type).to.equal('exists');
+                    expect(value).to.equal(123);
+                    done();
+                };
+                br.client._addToServerQueue('* 123 EXISTS');
+            });
+
+            it('should receive information about untagged expunge', function(done) {
+                br.client._connectionReady = true;
+                br.onupdate = function(type, value){
+                    expect(type).to.equal('expunge');
+                    expect(value).to.equal(456);
+                    done();
+                };
+                br.client._addToServerQueue('* 456 EXPUNGE');
+            });
+
+            it('should receive information about untagged fetch', function(done) {
+                br.client._connectionReady = true;
+                br.onupdate = function(type, value){
+                    expect(type).to.equal('fetch');
+                    expect(value).to.deep.equal({
+                        '#': 123,
+                        'flags': ['\\Seen'],
+                        'modseq': 4
+                    });
+                    done();
+                };
+                br.client._addToServerQueue('* 123 FETCH (FLAGS (\\Seen) MODSEQ (4))');
+            });
+        });
+
         /* jshint indent:false */
 
     });


### PR DESCRIPTION
As I was already on it, I also implemented untagged response handler. See [update notifications](https://github.com/whiteout-io/browserbox/tree/untagged#update-notifications) for details
