### PR TITLE
Handle NIL delimiters

### DIFF
--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -645,7 +645,7 @@
                 if (!item || !item.attributes || item.attributes.length < 3) {
                     return;
                 }
-                var branch = this._ensurePath(tree, (item.attributes[2].value || '').toString(), (item.attributes[1].value).toString());
+                var branch = this._ensurePath(tree, (item.attributes[2].value || '').toString(), (item.attributes[1] ? item.attributes[1].value : '/').toString());
                 branch.flags = [].concat(item.attributes[0] || []).map(function(flag) {
                     return (flag.value || '').toString();
                 });


### PR DESCRIPTION
Without the fix portion of this patch, the test results in the following failure:

```
  1) browserbox unit tests #listMailboxes should not die on NIL separators:
     TypeError: 'null' is not an object (evaluating 'item.attributes[1].value')
      at file:///home/visbrero/rev_control/fgit/browserbox/test/lib/browserbox.js:648
      at file:///home/visbrero/rev_control/fgit/browserbox/test/unit/unit.js:29
```

Per the RFC 3501 grammar, nil is okay here:

```
mailbox-list    = "(" [mbx-list-flags] ")" SP
                   (DQUOTE QUOTED-CHAR DQUOTE / nil) SP mailbox
```

The patch herein defaults to a '/' delimiter for the inbox, but that's probably not the right thing to do either.  I would guess one would want to fall back to what NAMESPACE has to say, except in this case, the server I'm dealing with doesn't support NAMESPACE and generally seems to be less than great.

Here's an aggregated trace for your edification / shock and horror at this implementation :)

```
* OK [CAPABILITY IMAP4rev1 LITERAL+] IMAP4rev1 SEINE IMAP server ready (0.17.131210.01)
A1 CAPABILITY
* CAPABILITY SEINE IMAP server IMAP4rev1 LITERAL+
A1 OK CAPABILITY completed
A2 LIST "" "*"
* LIST (\NoInferiors) NIL "INBOX"
* LIST (\NoInferiors \UnMarked) "/" "&sLSsjMT0ulTHfNVo-"
* LIST (\NoInferiors \UnMarked) "/" "Sent Messages"
* LIST (\NoInferiors \UnMarked) "/" "Drafts"
* LIST (\NoInferiors \UnMarked) "/" "Deleted Messages"
* LIST (\NoInferiors \UnMarked) "/" "&yBXQbA- &ulTHfA-"
* LIST (\NoInferiors \UnMarked) "/" "&wfzVUdVo-"
* LIST (\NoInferiors \UnMarked) "/" "SNS&1Wg-"
* LIST (\NoInferiors \UnMarked) "/" "&vPSwvA- &07jJwNVo-"
A2 OK LIST completed
A3 LSUB "" "*"
* LSUB (\NoInferiors) NIL "INBOX"
* LSUB () "/" "&sLSsjMT0ulTHfNVo-"
* LSUB () "/" "Sent Messages"
* LSUB () "/" "Drafts"
* LSUB () "/" "Deleted Messages"
* LSUB () "/" "&yBXQbA- &ulTHfA-"
* LSUB () "/" "&wfzVUdVo-"
* LSUB () "/" "SNS&1Wg-"
* LSUB () "/" "&vPSwvA- &07jJwNVo-"
A3 OK LSUB completed
```
