### PR TITLE
handle NIL in LSUB in addition to LIST too.

### DIFF
--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -672,7 +672,7 @@
                     if (!item || !item.attributes || item.attributes.length < 3) {
                         return;
                     }
-                    var branch = this._ensurePath(tree, (item.attributes[2].value || '').toString(), (item.attributes[1].value).toString());
+                    var branch = this._ensurePath(tree, (item.attributes[2].value || '').toString(), (item.attributes[1] ? item.attributes[1].value : '/').toString());
                     [].concat(item.attributes[0] || []).map(function(flag) {
                         flag = (flag.value || '').toString();
                         if (!branch.flags || branch.flags.indexOf(flag) < 0) {

--- a/test/unit/browserbox-test.js
+++ b/test/unit/browserbox-test.js
@@ -518,7 +518,9 @@
                         });
                         callback(null, {
                             payload: {
-                                LSUB: [false]
+                                LSUB: [
+                                    imapHandler.parser('* LSUB (\\NoInferiors) NIL "INBOX"')
+                                ]
                             }
                         }, function() {
                             done();


### PR DESCRIPTION
Whoops!  I was hurrying a bit and although I dealt with LIST in https://github.com/whiteout-io/browserbox/pull/27 I completely forgot to check and handle the LSUB case in my haste.  (We hadn't previously used LSUB ourselves.)  Apologies; I'll try and make sure to run full local tests before putting up pull requests in the future.  Things should get easier when we're 100% up-to-date with browserbox upstream in our rep.
