### PR TITLE
Fix usage of onerror in the onclose section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Where
 Is fired when the connection to the IMAP server is closed.
 
 ```
-client.onerror = function(err){}
+client.onclose = function(){}
 ```
 
 ### onauth


### PR DESCRIPTION
Update the example to 
- use `onclose` and not `onerror`
- remove the `err` argument passed to the callback
