### PR TITLE
[WO-730] Do not run 'CAPABILITY' before upgrading connection with the requireTLS option

### DIFF
--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -423,8 +423,15 @@
             callback = forced;
             forced = undefined;
         }
+
         // skip request, if not forced update and capabilities are already loaded
         if (!forced && this.capability.length) {
+            return callback(null, false);
+        }
+
+        // If STARTTLS is required then skip capability listing as we are going to try
+        // STARTTLS anyway and we re-check capabilities after connection is secured
+        if (!this.client.secureMode && this.options.requireTLS) {
             return callback(null, false);
         }
 

--- a/test/unit/browserbox-test.js
+++ b/test/unit/browserbox-test.js
@@ -312,6 +312,17 @@
 
                 br.exec.restore();
             });
+
+            it('should do nothing if connection is not yet upgraded', function() {
+                br.capability = [];
+                br.client.secureMode = false;
+                br.options.requireTLS = true;
+
+                br.updateCapability(function(err, updated) {
+                    expect(err).to.not.exist;
+                    expect(updated).to.be.false;
+                });
+            });
         });
 
         describe('#listNamespaces', function() {


### PR DESCRIPTION
Fixes #35 
