### PR TITLE
Do not quote Date objects in SEARCH to appease yandex IMAP

### DIFF
--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -1671,8 +1671,12 @@
                                 value: param
                             };
                         } else if (Object.prototype.toString.call(param) === "[object Date]") {
+                            // RFC 3501 allows for dates to be placed in
+                            // double-quotes or left without quotes.  Some
+                            // servers (Yandex), do not like the double quotes,
+                            // so we treat the date as an atom.
                             return {
-                                type: "string",
+                                type: "atom",
                                 value: formatDate(param)
                             };
                         } else if (Array.isArray(param)) {

--- a/test/unit/browserbox-test.js
+++ b/test/unit/browserbox-test.js
@@ -1545,13 +1545,13 @@
                         'type': 'atom',
                         'value': 'SENTBEFORE'
                     }, {
-                        'type': 'string',
+                        'type': 'atom',
                         'value': '3-Feb-2011'
                     }, {
                         'type': 'atom',
                         'value': 'SINCE'
                     }, {
-                        'type': 'string',
+                        'type': 'atom',
                         'value': '23-Dec-2011'
                     }, {
                         'type': 'atom',


### PR DESCRIPTION
The RFC 3501 grammar for date is:

```
date            = date-text / DQUOTE date-text DQUOTE
date-text       = date-day "-" date-month "-" date-year
```

Currently the search functionality emits dates as strings which results
in them being double-quoted.  This is legal, although section 6.4.4's
example does not use the quotes.

The problem is that the Yandex IMAP server, at least, does not like the
quotes.  In my tests, if I send 'W6 UID SEARCH NOT DELETED SINCE "1-Jan-1990"'
I get back 'W6 Command syntax error.'  However, if I do not quote the date,
things work.

This patch changes the behaviour in a non-configurable fashion since the
assumption is that all servers can handle the unquoted form and it's also
less bytes on the wire.

I checked the grammar and the only place that "date" is used is inside SEARCH,
so hopefully there are no other cases where something like this needs to be
done.  (APPEND explicitly uses "date-time" which is explicitly wrapped in
DQUOTEs.)
