### PR TITLE
Implement minimal createMailbox CREATE feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,26 @@ client.listNamespaces(function(err, namespaces){
 }
 ```
 
+## Create mailbox
+
+Create a folder with the given path, automatically handling utf-7 encoding.  You
+currently need to manually build the path string yourself.  (There is potential
+for future enhancement to provide assistance.)
+
+If the server indicates a failure but that the folder already exists with the
+ALREADYEXISTS response code, the request will be treated as a success.
+
+Example
+
+```javascript
+// On a server with a personal namesapce of INBOX and a delimiter of '/',
+// create folder Foo.  Note that folders using a non-empty personal namespace
+// may automatically assume the personal namespace.
+client.createMailbox('INBOX/Foo', function callback(err, alreadyExists) {});
+// Do the same on a server where the personal namespace is ''
+client.createMailbox('Foo', function callback(err, alreadyExists) {});
+```
+
 ## Select mailbox
 
 Select specific mailbox by path with `selectMailbox()`

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -715,6 +715,37 @@
     };
 
     /**
+     * Create a mailbox with the given path.
+     *
+     * CREATE details:
+     *   http://tools.ietf.org/html/rfc3501#section-6.3.3
+     *
+     * @param {String} path
+     *     The path of the mailbox you would like to create.  This method will
+     *     handle utf7 encoding for you.
+     * @param {Function} callback
+     *     Callback that takes an error argument and a boolean indicating
+     *     whether the folder already existed.  If the mailbox creation
+     *     succeeds, the error argument will be null.  If creation fails, error
+     *     will have an error value.  In the event the server says NO
+     *     [ALREADYEXISTS], we treat that as success and return true for the
+     *     second argument.
+     */
+    BrowserBox.prototype.createMailbox = function(path, callback) {
+        this.exec({
+            command: 'CREATE',
+            attributes: [utf7.imap.encode(path)]
+        }, function(err, response, next) {
+            if (err && err.code === 'ALREADYEXISTS') {
+                callback(null, true);
+            } else {
+                callback(err, false);
+            }
+            next();
+        });
+    };
+
+    /**
      * Runs FETCH command
      *
      * FETCH details:


### PR DESCRIPTION
Since folder management is not entirely trivial given the interaction of
namespaces and delimiters, it could make sense to also support some type
of slightly higher level API as well.

This could entail having listNamespaces and listMailboxes called together
and retain their results, which starts to get tricky.  So for now I figured
I would just implement the low level CREATE binding.

(In gaia-email-libs-and-more we've got some existing logic which I've now cleaned up.  I've also added a bunch of unit tests in a pending pull request.  I can try to upstream that once we reach consensus.)
