### PR TITLE
Allow users to set TCPSocket options directly

### DIFF
--- a/test/integration/browserbox-test.js
+++ b/test/integration/browserbox-test.js
@@ -87,7 +87,9 @@
                         user: "testuser",
                         pass: "testpass"
                     },
-                    useSecureTransport: false
+                    tcpSocket: {
+                        useSecureTransport: false
+                    }
                 });
 
                 imap.onerror = () => {
@@ -107,7 +109,9 @@
                         user: "testuser",
                         pass: "testpass"
                     },
-                    useSecureTransport: false,
+                    tcpSocket: {
+                        useSecureTransport: false
+                    },
                     ignoreTLS: true
                 });
 
@@ -124,7 +128,9 @@
                         user: "testuser",
                         pass: "testpass"
                     },
-                    useSecureTransport: false,
+                    tcpSocket: {
+                        useSecureTransport: false
+                    },
                     requireTLS: true
                 });
 
@@ -140,7 +146,9 @@
                         user: "testuser",
                         pass: "testpass"
                     },
-                    useSecureTransport: false
+                    tcpSocket: {
+                        useSecureTransport: false
+                    }
                 });
 
                 imap.connect().then(() => {
@@ -159,7 +167,9 @@
                         user: "testuser",
                         pass: "testpass"
                     },
-                    useSecureTransport: false
+                    tcpSocket: {
+                        useSecureTransport: false
+                    }
                 });
 
                 imap.connect().then(() => {
@@ -367,7 +377,9 @@
                         user: "testuser",
                         pass: "testpass"
                     },
-                    useSecureTransport: false
+                    tcpSocket: {
+                        useSecureTransport: false
+                    }
                 });
 
                 imap.connect().then(done);


### PR DESCRIPTION
Currently the code attempts to map options to the TCPSocket. This PR adds a tcpSocket property to the options object that is provided to TCPSocket.connect as its options. This allows the features of the underlying shims to evolve without needing to modify BrowserBox.

This PR was motivated by my need to set the ws.url for a socket.io proxy running on a host other than the one serving the client code.