### PR TITLE
Fix memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,8 +684,6 @@ The IMAP client has several events you can attach to by setting a listener
 
 The invocation of `onerror` indicates an irrecoverable error. When `onerror` is fired, the connection is already closed, hence there's no need for further cleanup.
 
-**NB! This handler is mandatory!**
-
 ### TCP-Socket related events
 
 Should you be using the TCP-Socket shim on a platform that has no native support for TLS, the certificate of the remote host is propagated via the `oncert` event. The only argument is the PEM-encoded X.501 TLS certificate, however this doesn't include the whole certificate chain.

--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -157,10 +157,15 @@
 
                 if (this.socket) {
                     // remove all listeners
-                    this.socket.onclose = () => {};
-                    this.socket.ondata = () => {};
-                    this.socket.ondrain = () => {};
-                    this.socket.onerror = () => {};
+                    this.socket.onopen = null;
+                    this.socket.onclose = null;
+                    this.socket.ondata = null;
+                    this.socket.onerror = null;
+                    try {
+                        this.socket.oncert = null;
+                    } catch (E) {}
+
+                    this.socket = null;
                 }
 
                 resolve();

--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -152,8 +152,12 @@
             var tearDown = () => {
                 this._clientQueue = [];
                 this._currentCommand = false;
+
                 clearTimeout(this._idleTimer);
+                this._idleTimer = null;
+
                 clearTimeout(this._socketTimeoutTimer);
+                this._socketTimeoutTimer = null;
 
                 if (this.socket) {
                     // remove all listeners
@@ -343,6 +347,8 @@
      */
     Imap.prototype._onData = function(evt) {
         clearTimeout(this._socketTimeoutTimer); // clear the timeout, the socket is still up
+        this._socketTimeoutTimer = null;
+
         this._incomingBuffer += mimecodec.fromTypedArray(evt.data); // append to the incoming buffer
         this._parseIncomingCommands(this._iterateIncomingBuffer()); // Consume the incoming buffer
     };
@@ -548,6 +554,7 @@
      */
     Imap.prototype._clearIdle = function() {
         clearTimeout(this._idleTimer);
+        this._idleTimer = null;
     };
 
     /**

--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -79,7 +79,7 @@
 
         // propagate the error upwards
         this.onerror && this.onerror(err);
-    }
+    };
 
     //
     //

--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -32,10 +32,10 @@
         this.serverId = false; // RFC 2971 Server ID as key value pairs
 
         // Event placeholders
-        this.oncert = () => {};
-        this.onupdate = () => {};
-        this.onselectmailbox = () => {};
-        this.onclosemailbox = () => {};
+        this.oncert = null;
+        this.onupdate = null;
+        this.onselectmailbox = null;
+        this.onclosemailbox = null;
 
         //
         // Internals
@@ -54,7 +54,7 @@
 
         // Event Handlers
         this.client.onerror = this._onError.bind(this);
-        this.client.oncert = (cert) => this.oncert(cert); // allows certificate handling for platforms w/o native tls support
+        this.client.oncert = (cert) => (this.oncert && this.oncert(cert)); // allows certificate handling for platforms w/o native tls support
         this.client.onidle = () => this._onIdle(); // start idling
 
         // Default handlers for untagged responses
@@ -256,7 +256,7 @@
             this._changeState(this.STATE_SELECTED);
 
             if (this._selectedMailbox && this._selectedMailbox !== path) {
-                this.onclosemailbox(this._selectedMailbox);
+                this.onclosemailbox && this.onclosemailbox(this._selectedMailbox);
             }
 
             this._selectedMailbox = path;
@@ -264,7 +264,7 @@
             var mailboxInfo = this._parseSELECT(response);
 
             setTimeout(() => {
-                this.onselectmailbox(path, mailboxInfo);
+                this.onselectmailbox && this.onselectmailbox(path, mailboxInfo);
             }, 0);
 
             return mailboxInfo;
@@ -936,7 +936,7 @@
      */
     Client.prototype._untaggedExistsHandler = function(response) {
         if (response && response.hasOwnProperty('nr')) {
-            this.onupdate(this.selectedMailbox, 'exists', response.nr);
+            this.onupdate && this.onupdate(this.selectedMailbox, 'exists', response.nr);
         }
     };
 
@@ -948,7 +948,7 @@
      */
     Client.prototype._untaggedExpungeHandler = function(response) {
         if (response && response.hasOwnProperty('nr')) {
-            this.onupdate(this.selectedMailbox, 'expunge', response.nr);
+            this.onupdate && this.onupdate(this.selectedMailbox, 'expunge', response.nr);
         }
     };
 
@@ -959,7 +959,7 @@
      * @param {Function} next Until called, server responses are not processed
      */
     Client.prototype._untaggedFetchHandler = function(response) {
-        this.onupdate(this.selectedMailbox, 'fetch', [].concat(this._parseFETCH({
+        this.onupdate && this.onupdate(this.selectedMailbox, 'fetch', [].concat(this._parseFETCH({
             payload: {
                 FETCH: [response]
             }
@@ -1662,7 +1662,7 @@
 
         // if a mailbox was opened, emit onclosemailbox and clear selectedMailbox value
         if (this._state === this.STATE_SELECTED && this._selectedMailbox) {
-            this.onclosemailbox(this._selectedMailbox);
+            this.onclosemailbox && this.onclosemailbox(this._selectedMailbox);
             this._selectedMailbox = false;
         }
 

--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -18,7 +18,7 @@
 
         /* jshint indent:false */
 
-        beforeEach((done) => {
+        beforeEach(() => {
             client = new ImapClient(host, port);
             expect(client).to.exist;
 
@@ -38,16 +38,16 @@
             socketStub = sinon.createStubInstance(TCPSocket);
             sinon.stub(TCPSocket, 'open').withArgs(host, port).returns(socketStub);
 
-            client.connect(TCPSocket).then(() => {
+            setTimeout(() => socketStub.onopen(), 0);
+
+            return client.connect(TCPSocket).then(() => {
                 expect(TCPSocket.open.callCount).to.equal(1);
 
                 expect(socketStub.onerror).to.exist;
                 expect(socketStub.onopen).to.exist;
                 expect(socketStub.onclose).to.exist;
                 expect(socketStub.ondata).to.exist;
-            }).then(done).catch(done);
-
-            setTimeout(() => socketStub.onopen(), 0);
+            });
         });
 
         describe('#close', () => {
@@ -55,7 +55,7 @@
                 client.socket.readyState = 'open';
 
                 client.close().then(() => {
-                    expect(client.socket.close.callCount).to.equal(1);
+                    expect(socketStub.close.callCount).to.equal(1);
                 }).then(done).catch(done);
 
                 setTimeout(() => socketStub.onclose(), 0);
@@ -65,7 +65,7 @@
                 client.socket.readyState = 'not open. duh.';
 
                 client.close().then(() => {
-                    expect(client.socket.close.called).to.be.false;
+                    expect(socketStub.close.called).to.be.false;
                 }).then(done).catch(done);
 
                 setTimeout(() => socketStub.onclose(), 0);
@@ -153,7 +153,7 @@
 
         describe('#_parseIncomingCommands', () => {
             it('should process a tagged item from the queue', () => {
-                sinon.stub(client, 'onready');
+                client.onready = sinon.stub();
                 sinon.stub(client, '_handleResponse');
 
                 function* gen() { yield 'OK Hello world!'; }

--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -38,9 +38,7 @@
             socketStub = sinon.createStubInstance(TCPSocket);
             sinon.stub(TCPSocket, 'open').withArgs(host, port).returns(socketStub);
 
-            setTimeout(() => socketStub.onopen(), 0);
-
-            return client.connect(TCPSocket).then(() => {
+            var promise = client.connect(TCPSocket).then(() => {
                 expect(TCPSocket.open.callCount).to.equal(1);
 
                 expect(socketStub.onerror).to.exist;
@@ -48,6 +46,10 @@
                 expect(socketStub.onclose).to.exist;
                 expect(socketStub.ondata).to.exist;
             });
+
+            setTimeout(() => socketStub.onopen(), 0);
+
+            return promise;
         });
 
         describe('#close', () => {

--- a/test/unit/emailjs-imap-client-test.js
+++ b/test/unit/emailjs-imap-client-test.js
@@ -926,7 +926,7 @@
 
         describe('#_untaggedExistsHandler', () => {
             it('should emit onupdate', () => {
-                sinon.stub(br, 'onupdate');
+                br.onupdate = sinon.stub();
                 br.selectedMailbox = 'FOO';
 
                 br._untaggedExistsHandler({
@@ -938,7 +938,7 @@
 
         describe('#_untaggedExpungeHandler', () => {
             it('should emit onupdate', () => {
-                sinon.stub(br, 'onupdate');
+                br.onupdate = sinon.stub();
                 br.selectedMailbox = 'FOO';
 
                 br._untaggedExpungeHandler({
@@ -950,7 +950,7 @@
 
         describe('#_untaggedFetchHandler', () => {
             it('should emit onupdate', () => {
-                sinon.stub(br, 'onupdate');
+                br.onupdate = sinon.stub();
                 sinon.stub(br, '_parseFETCH').returns('abc');
                 br.selectedMailbox = 'FOO';
 
@@ -1843,7 +1843,7 @@
             });
 
             it('should emit onclosemailbox if mailbox was closed', () => {
-                sinon.stub(br, 'onclosemailbox');
+                br.onclosemailbox = sinon.stub();
                 br._state = br.STATE_SELECTED;
                 br._selectedMailbox = 'aaa';
 


### PR DESCRIPTION
When instances of the IMAP client class get repeatedly constructed and destroyed, for instance when the connection to the server gets interrupted and has to be re-established frequently, large amounts of resources would get leaked. In my tests, I saw several hundreds of MB filling up the heap within a few minutes of reconnecting every 20s.

This PR mainly fixes these problems:

- when the Imap class closed its TCPSocket, it would set the socket callbacks to `() => {}`. It seems that these arrow functions still contained an implicit closure over `this`, meaning the Imap class would never get deallocated. I therefore replaced these callbacks by `null`, which the TCPSocket API allows.
- when the Imap class closes its TCPSocket, it now sets the socket reference to null so that the TCPSocket may get garbage collected.
- when the Client class receives an error from the Imap class, it now makes sure that the idle timeout is cleared. It used to keep running, meaning that read() would be called on a now invalid socket, which lead to all sorts of issues.

This PR doesn't change the external interface of the package, except that the Client callbacks are now allowed to be null. In particular, it's not mandatory to set `onerror` anymore. This is a backwards compatible change and shouldn't break any existing code which uses this package.