### PR TITLE
Fix onupdate

### DIFF
--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -936,7 +936,7 @@
      */
     Client.prototype._untaggedExistsHandler = function(response) {
         if (response && response.hasOwnProperty('nr')) {
-            this.onupdate && this.onupdate(this.selectedMailbox, 'exists', response.nr);
+            this.onupdate && this.onupdate(this._selectedMailbox, 'exists', response.nr);
         }
     };
 
@@ -948,7 +948,7 @@
      */
     Client.prototype._untaggedExpungeHandler = function(response) {
         if (response && response.hasOwnProperty('nr')) {
-            this.onupdate && this.onupdate(this.selectedMailbox, 'expunge', response.nr);
+            this.onupdate && this.onupdate(this._selectedMailbox, 'expunge', response.nr);
         }
     };
 
@@ -959,7 +959,7 @@
      * @param {Function} next Until called, server responses are not processed
      */
     Client.prototype._untaggedFetchHandler = function(response) {
-        this.onupdate && this.onupdate(this.selectedMailbox, 'fetch', [].concat(this._parseFETCH({
+        this.onupdate && this.onupdate(this._selectedMailbox, 'fetch', [].concat(this._parseFETCH({
             payload: {
                 FETCH: [response]
             }

--- a/test/integration/emailjs-imap-client-test.js
+++ b/test/integration/emailjs-imap-client-test.js
@@ -81,7 +81,7 @@
                 insecureServer.close(done);
             });
 
-            it('should use STARTTLS by default', (done) => {
+            it('should use STARTTLS by default', () => {
                 imap = new ImapClient('127.0.0.1', port, {
                     auth: {
                         user: "testuser",
@@ -91,18 +91,14 @@
                 });
                 imap.logLevel = imap.LOG_LEVEL_NONE;
 
-                imap.onerror = () => {
-                    done();
-                };
-
-                imap.connect().then(() => {
+                return imap.connect().then(() => {
                     expect(imap.client.secureMode).to.be.true;
                 }).then(() => {
                     return imap.close();
-                }).then(done).catch(done);
+                });
             });
 
-            it('should ignore STARTTLS', (done) => {
+            it('should ignore STARTTLS', () => {
                 imap = new ImapClient('127.0.0.1', port, {
                     auth: {
                         user: "testuser",
@@ -113,11 +109,11 @@
                 });
                 imap.logLevel = imap.LOG_LEVEL_NONE;
 
-                imap.connect().then(() => {
+                return imap.connect().then(() => {
                     expect(imap.client.secureMode).to.be.false;
                 }).then(() => {
                     return imap.close();
-                }).then(done).catch(done);
+                });
             });
 
             it('should fail connecting to non-STARTTLS host', (done) => {
@@ -137,7 +133,7 @@
                 });
             });
 
-            it('should connect to non secure host', (done) => {
+            it('should connect to non secure host', () => {
                 imap = new ImapClient('127.0.0.1', port + 2, {
                     auth: {
                         user: "testuser",
@@ -147,17 +143,17 @@
                 });
                 imap.logLevel = imap.LOG_LEVEL_NONE;
 
-                imap.connect().then(() => {
+                return imap.connect().then(() => {
                     expect(imap.client.secureMode).to.be.false;
                 }).then(() => {
                     return imap.close();
-                }).then(done).catch(done);
+                });
             });
         });
 
         describe('Post login tests', () => {
 
-            beforeEach((done) => {
+            beforeEach(() => {
                 imap = new ImapClient('127.0.0.1', port, {
                     auth: {
                         user: "testuser",
@@ -167,38 +163,36 @@
                 });
                 imap.logLevel = imap.LOG_LEVEL_NONE;
 
-                imap.connect().then(() => {
+                return imap.connect().then(() => {
                     return imap.selectMailbox('[Gmail]/Spam');
-                }).then(() => {
-                    done();
-                }).catch(done);
+                });
             });
 
-            afterEach((done) => {
-                imap.close().then(done);
+            afterEach(() => {
+                return imap.close();
             });
 
             describe('#listMailboxes', () => {
-                it('should succeed', (done) => {
-                    imap.listMailboxes().then((mailboxes) => {
+                it('should succeed', () => {
+                    return imap.listMailboxes().then((mailboxes) => {
                         expect(mailboxes).to.exist;
-                    }).then(done).catch(done);
+                    });
                 });
             });
 
             describe('#listMessages', () => {
-                it('should succeed', (done) => {
-                    imap.listMessages('inbox', "1:*", ["uid", "flags", "envelope", "bodystructure", "body.peek[]"]).then((messages) => {
+                it('should succeed', () => {
+                    return imap.listMessages('inbox', "1:*", ["uid", "flags", "envelope", "bodystructure", "body.peek[]"]).then((messages) => {
                         expect(messages).to.not.be.empty;
-                    }).then(done).catch(done);
+                    });
                 });
             });
 
             describe('#upload', () => {
-                it('should succeed', (done) => {
+                it('should succeed', () => {
                     var msgCount;
 
-                    imap.listMessages('inbox', "1:*", ["uid", "flags", "envelope", "bodystructure"]).then((messages) => {
+                    return imap.listMessages('inbox', "1:*", ["uid", "flags", "envelope", "bodystructure"]).then((messages) => {
                         expect(messages).to.not.be.empty;
                         msgCount = messages.length;
                     }).then(() => {
@@ -209,62 +203,62 @@
                         return imap.listMessages('inbox', "1:*", ["uid", "flags", "envelope", "bodystructure"]);
                     }).then((messages) => {
                         expect(messages.length).to.equal(msgCount + 1);
-                    }).then(done).catch(done);
+                    });
                 });
             });
 
             describe('#search', () => {
-                it('should return a sequence number', (done) => {
-                    imap.search('inbox', {
+                it('should return a sequence number', () => {
+                    return imap.search('inbox', {
                         header: ['subject', 'hello 3']
                     }).then((result) => {
                         expect(result).to.deep.equal([3]);
-                    }).then(done).catch(done);
+                    });
                 });
 
-                it('should return an uid', (done) => {
-                    imap.search('inbox', {
+                it('should return an uid', () => {
+                    return imap.search('inbox', {
                         header: ['subject', 'hello 3']
                     }, {
                         byUid: true
                     }).then((result) => {
                         expect(result).to.deep.equal([555]);
-                    }).then(done).catch(done);
+                    });
                 });
 
-                it('should work with complex queries', (done) => {
-                    imap.search('inbox', {
+                it('should work with complex queries', () => {
+                    return imap.search('inbox', {
                         header: ['subject', 'hello'],
                         seen: true
                     }).then((result) => {
                         expect(result).to.deep.equal([2]);
-                    }).then(done).catch(done);
+                    });
                 });
             });
 
             describe('#setFlags', () => {
-                it('should set flags for a message', (done) => {
-                    imap.setFlags('inbox', '1', ['\\Seen', '$MyFlag']).then((result) => {
+                it('should set flags for a message', () => {
+                    return imap.setFlags('inbox', '1', ['\\Seen', '$MyFlag']).then((result) => {
                         expect(result).to.deep.equal([{
                             '#': 1,
                             'flags': ['\\Seen', '$MyFlag']
                         }]);
-                    }).then(done).catch(done);
+                    });
                 });
 
-                it('should add flags to a message', (done) => {
-                    imap.setFlags('inbox', '2', {
+                it('should add flags to a message', () => {
+                    return imap.setFlags('inbox', '2', {
                         add: ['$MyFlag']
                     }).then((result) => {
                         expect(result).to.deep.equal([{
                             '#': 2,
                             'flags': ['\\Seen', '$MyFlag']
                         }]);
-                    }).then(done).catch(done);
+                    });
                 });
 
-                it('should remove flags from a message', (done) => {
-                    imap.setFlags('inbox', '557', {
+                it('should remove flags from a message', () => {
+                    return imap.setFlags('inbox', '557', {
                         remove: ['\\Deleted']
                     }, {
                         byUid: true
@@ -274,44 +268,44 @@
                             'flags': ['$MyFlag'],
                             'uid': 557
                         }]);
-                    }).then(done).catch(done);
+                    });
                 });
 
-                it('should not return anything on silent mode', (done) => {
-                    imap.setFlags('inbox', '1', ['$MyFlag2'], {
+                it('should not return anything on silent mode', () => {
+                    return imap.setFlags('inbox', '1', ['$MyFlag2'], {
                         silent: true
                     }).then((result) => {
                         expect(result).to.deep.equal([]);
-                    }).then(done).catch(done);
+                    });
                 });
             });
 
             describe('#store', () => {
-                it('should add labels for a message', (done) => {
-                    imap.store('inbox', '1', '+X-GM-LABELS', ['\\Sent', '\\Junk']).then((result) => {
+                it('should add labels for a message', () => {
+                    return imap.store('inbox', '1', '+X-GM-LABELS', ['\\Sent', '\\Junk']).then((result) => {
                         expect(result).to.deep.equal([{
                             '#': 1,
                             'x-gm-labels': ['\\Inbox', '\\Sent', '\\Junk']
                         }]);
-                    }).then(done).catch(done);
+                    });
                 });
 
-                it('should set labels for a message', (done) => {
-                    imap.store('inbox', '1', 'X-GM-LABELS', ['\\Sent', '\\Junk']).then((result) => {
+                it('should set labels for a message', () => {
+                    return imap.store('inbox', '1', 'X-GM-LABELS', ['\\Sent', '\\Junk']).then((result) => {
                         expect(result).to.deep.equal([{
                             '#': 1,
                             'x-gm-labels': ['\\Sent', '\\Junk']
                         }]);
-                    }).then(done).catch(done);
+                    });
                 });
 
-                it('should remove labels from a message', (done) => {
-                    imap.store('inbox', '1', '-X-GM-LABELS', ['\\Sent', '\\Inbox']).then((result) => {
+                it('should remove labels from a message', () => {
+                    return imap.store('inbox', '1', '-X-GM-LABELS', ['\\Sent', '\\Inbox']).then((result) => {
                         expect(result).to.deep.equal([{
                             '#': 1,
                             'x-gm-labels': []
                         }]);
-                    }).then(done).catch(done);
+                    });
                 });
             });
 
@@ -345,21 +339,21 @@
             });
 
             describe('#copyMessages', () => {
-                it('should copy a message', (done) => {
-                    imap.copyMessages('inbox', 555, '[Gmail]/Trash', {
+                it('should copy a message', () => {
+                    return imap.copyMessages('inbox', 555, '[Gmail]/Trash', {
                         byUid: true
                     }).then(() => {
                         return imap.selectMailbox('[Gmail]/Trash');
                     }).then((info) => {
                         expect(info.exists).to.equal(1);
-                    }).then(done).catch(done);
+                    });
                 });
             });
 
             describe('#moveMessages', () => {
-                it('should move a message', (done) => {
+                it('should move a message', () => {
                     var initialInfo;
-                    imap.selectMailbox('inbox').then((info) => {
+                    return imap.selectMailbox('inbox').then((info) => {
                         initialInfo = info;
                         return imap.moveMessages('inbox', 555, '[Gmail]/Spam', {
                             byUid: true
@@ -371,7 +365,7 @@
                         return imap.selectMailbox('inbox');
                     }).then((resultInfo) => {
                         expect(initialInfo.exists).to.not.equal(resultInfo.exists);
-                    }).then(done).catch(done);
+                    });
                 });
             });
 
@@ -402,7 +396,7 @@
 
         describe('Timeout', () => {
 
-            beforeEach((done) => {
+            beforeEach(() => {
                 imap = new ImapClient('127.0.0.1', port, {
                     auth: {
                         user: "testuser",
@@ -412,7 +406,7 @@
                 });
                 imap.logLevel = imap.LOG_LEVEL_NONE;
 
-                imap.connect().then(done);
+                return imap.connect();
             });
 
             it('should timeout', (done) => {

--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -47,7 +47,7 @@
                 expect(socketStub.ondata).to.exist;
             });
 
-            setTimeout(() => socketStub.onopen(), 0);
+            setTimeout(() => socketStub.onopen(), 10);
 
             return promise;
         });

--- a/test/unit/emailjs-imap-client-test.js
+++ b/test/unit/emailjs-imap-client-test.js
@@ -927,7 +927,7 @@
         describe('#_untaggedExistsHandler', () => {
             it('should emit onupdate', () => {
                 br.onupdate = sinon.stub();
-                br.selectedMailbox = 'FOO';
+                br._selectedMailbox = 'FOO';
 
                 br._untaggedExistsHandler({
                     nr: 123
@@ -939,7 +939,7 @@
         describe('#_untaggedExpungeHandler', () => {
             it('should emit onupdate', () => {
                 br.onupdate = sinon.stub();
-                br.selectedMailbox = 'FOO';
+                br._selectedMailbox = 'FOO';
 
                 br._untaggedExpungeHandler({
                     nr: 123
@@ -952,7 +952,7 @@
             it('should emit onupdate', () => {
                 br.onupdate = sinon.stub();
                 sinon.stub(br, '_parseFETCH').returns('abc');
-                br.selectedMailbox = 'FOO';
+                br._selectedMailbox = 'FOO';
 
                 br._untaggedFetchHandler({
                     nr: 123
@@ -1979,7 +1979,7 @@
         describe('untagged updates', () => {
             it('should receive information about untagged exists', (done) => {
                 br.client._connectionReady = true;
-                br.selectedMailbox = 'FOO';
+                br._selectedMailbox = 'FOO';
                 br.onupdate = (path, type, value) => {
                     expect(path).to.equal('FOO');
                     expect(type).to.equal('exists');
@@ -1994,7 +1994,7 @@
 
             it('should receive information about untagged expunge', (done) => {
                 br.client._connectionReady = true;
-                br.selectedMailbox = 'FOO';
+                br._selectedMailbox = 'FOO';
                 br.onupdate = (path, type, value) => {
                     expect(path).to.equal('FOO');
                     expect(type).to.equal('expunge');
@@ -2009,7 +2009,7 @@
 
             it('should receive information about untagged fetch', (done) => {
                 br.client._connectionReady = true;
-                br.selectedMailbox = 'FOO';
+                br._selectedMailbox = 'FOO';
                 br.onupdate = (path, type, value) => {
                     expect(path).to.equal('FOO');
                     expect(type).to.equal('fetch');


### PR DESCRIPTION
In the code calling the `onupdate` callback, `selectedMailbox` was being used instead of `_selectedMailbox`, which is undefined.

I extended the `#deleteMessages` integration test to show this problem, fixed the bug and fixed the unit tests which relied on the faulty behavior. I also cleaned up some of the integration tests using promises while I was there.

Fixes #84.