### PR TITLE
Don't select mailbox before onselectmailbox for previous selection is done

### DIFF
--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -263,11 +263,12 @@
 
             var mailboxInfo = this._parseSELECT(response);
 
-            setTimeout(() => {
-                this.onselectmailbox && this.onselectmailbox(path, mailboxInfo);
-            }, 0);
-
-            return mailboxInfo;
+            var maybePromise = this.onselectmailbox && this.onselectmailbox(path, mailboxInfo);
+            if (maybePromise && typeof maybePromise.then === 'function') {
+                return maybePromise.then(() => mailboxInfo);
+            } else {
+                return mailboxInfo;
+            }
         });
     };
 


### PR DESCRIPTION
This is a problem I didn't have with browserbox@0.9.1: I select mailboxes one by one after connecting to sync the local cache but sometimes the right mailbox is not selected at the time when listMessages() (called from onselectmailbox) is executed. I get this in an account with about 45k messages and 15 mailboxes, and currently don't have a anything reproducible that I can share.

This pull request fixes that use case by making sure onselectmailbox for one selection can finish before the next is executed. This changes the intended behavior of resolving selectMailbox before onselectmailbox is executed, dating back to aa2bf95bea665a where a callback is executed before calling onselectmailbox. It would be good get explaination to why it's done this way.

There might be an underlying issue here - I suspect something broke regarding the precheck code that verifies the correct mailbox is selected before executing IMAP commands. Perhaps when migrating to promises.