### PR TITLE
sessionId missing from logs

### DIFF
--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -1828,7 +1828,7 @@
             };
         };
 
-        var logger = this.options.logger || createLogger(this.logLevel, "emailjs-imap-client@" + this.options.sessionId);
+        var logger = this.options.logger || createLogger(this.options.sessionId || 1);
         this.logger = this.client.logger = {
             // this could become way nicer when node supports the rest operator...
             debug: function() {


### PR DESCRIPTION
It is vital too see which session owns each log when logging more than one connection.
Passing in the logLevel gives no additional info in the logs and the 2nd parameter passed in is ignored and hence I removed that.
This was in order in browserbox but has digressed.
Note that beforeEach in browserbox imap unit tests will fail unless the sessionId defaults to some defined value.
