### PR TITLE
wrap ondata in try/catch to avoid un-handled error

### DIFF
--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -128,7 +128,13 @@
 
             // Connection closing unexpected is an error
             this.socket.onclose = () => this._onError(new Error('Socket closed unexceptedly!'));
-            this.socket.ondata = (evt) => this._onData(evt);
+            this.socket.ondata = (evt) => {
+              try {
+                this._onData(evt);
+              } catch (err) {
+                reject(err);
+              }
+            };
 
             // if an error happens during create time, reject the promise
             this.socket.onerror = (e) => {

--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -132,7 +132,7 @@
               try {
                 this._onData(evt);
               } catch (err) {
-                reject(err);
+                this._onError(err);
               }
             };
 


### PR DESCRIPTION
The issue here was that the _onData method calls a function (fromTypedArray) imported from 'emailjs-mime-codec'. When a connection is unsuccessful we were experiencing an un-handled error from the (fromTypedArray) method that was not being caught in out client.connect().catch() error handler.

To fix this, I wrapped the _onData event in a try/catch handler. Now our error is bubbling all the way up to the catch statement