### PR TITLE
Fix module loading for webpack

### DIFF
--- a/src/emailjs-imap-client-compression.js
+++ b/src/emailjs-imap-client-compression.js
@@ -21,7 +21,7 @@
 (function(root, factory) {
     'use strict';
 
-    if (typeof define === 'function' && define.amd) {
+    if (typeof __webpack_require__ === 'undefined' && typeof define === 'function' && define.amd) {
         define(['emailjs-imap-client-pako'], factory);
     } else if (typeof exports === 'object') {
         module.exports = factory(require('./emailjs-imap-client-pako'));

--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -1,7 +1,7 @@
 (function(root, factory) {
     'use strict';
 
-    if (typeof define === 'function' && define.amd) {
+    if (typeof __webpack_require__ === 'undefined' && typeof define === 'function' && define.amd) {
         define(['emailjs-tcp-socket', 'emailjs-imap-handler', 'emailjs-mime-codec', 'emailjs-imap-client-compression'], factory);
     } else if (typeof exports === 'object') {
         module.exports = factory(require('emailjs-tcp-socket'), require('emailjs-imap-handler'), require('emailjs-mime-codec'), require('./emailjs-imap-client-compression'), null);

--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -1,7 +1,7 @@
 (function(root, factory) {
     'use strict';
 
-    if (typeof define === 'function' && define.amd) {
+    if (typeof __webpack_require__ === 'undefined' && typeof define === 'function' && define.amd) {
         define(['emailjs-imap-client-imap', 'emailjs-utf7', 'emailjs-imap-handler', 'emailjs-mime-codec', 'emailjs-addressparser'], factory);
     } else if (typeof exports === 'object') {
         module.exports = factory(require('./emailjs-imap-client-imap'), require('emailjs-utf7'), require('emailjs-imap-handler'), require('emailjs-mime-codec'), require('emailjs-addressparser'));


### PR DESCRIPTION
test with:
webpack --target=node src/emailjs-imap-client.js --output-file=out.js
node out.js

dependant code needs the same treatment
