### PR TITLE
Do not fail connection even though ID command fails

### DIFF
--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -117,7 +117,8 @@
         }).then(() => {
             return this.upgradeConnection();
         }).then(() => {
-            return this.updateId(this.options.id);
+            return this.updateId(this.options.id)
+            .catch(err => this.logger.warn('Failed to update id', err));
         }).then(() => {
             return this.login(this.options.auth);
         }).then(() => {


### PR DESCRIPTION
As an example poczta.o2.pl lists ID capability both before and after login while it only works after login.