### PR TITLE
Fixed a concurrency issue with precheck commands

### DIFF
--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -775,9 +775,8 @@
      * @param {Array} acceptUntagged a list of untagged responses that will be included in 'payload' property
      */
     Client.prototype.exec = function(request, acceptUntagged, options) {
-        return this.breakIdle().then(() => {
-            return this.client.enqueueCommand(request, acceptUntagged, options);
-        }).then((response) => {
+        this.breakIdle();
+        return this.client.enqueueCommand(request, acceptUntagged, options).then((response) => {
             if (response && response.capability) {
                 this._capability = response.capability;
             }
@@ -834,7 +833,7 @@
      */
     Client.prototype.breakIdle = function() {
         if (!this._enteredIdle) {
-            return Promise.resolve();
+            return;
         }
 
         clearTimeout(this._idleTimeout);
@@ -843,9 +842,6 @@
             this.logger.debug('Idle terminated');
         }
         this._enteredIdle = false;
-
-
-        return Promise.resolve();
     };
 
     /**

--- a/test/integration/emailjs-imap-client-test.js
+++ b/test/integration/emailjs-imap-client-test.js
@@ -46,7 +46,9 @@
                                     "Sent Mail": { "special-use": "\\Sent" },
                                     "Spam": { "special-use": "\\Junk" },
                                     "Starred": { "special-use": "\\Flagged" },
-                                    "Trash": { "special-use": "\\Trash" }
+                                    "Trash": { "special-use": "\\Trash" },
+                                    "A": { messages: [{}] },
+                                    "B": { messages: [{}] }
                                 }
                             }
                         }
@@ -388,6 +390,23 @@
                         return imap.selectMailbox('[Gmail]/Spam').then(() => {
                             done();
                         }).catch(done);
+                    });
+                });
+
+                it('should send precheck commands in correct order on concurrent calls', () => {
+                    return Promise.all([
+                        imap.setFlags('[Gmail]/A', '1', ['\\Seen']),
+                        imap.setFlags('[Gmail]/B', '1', ['\\Seen'])
+                    ]).then(() => {
+                        return imap.listMessages('[Gmail]/A', '1:1', ['flags']);
+                    }).then((messages) => {
+                        expect(messages.length).to.equal(1);
+                        expect(messages[0].flags).to.deep.equal(['\\Seen']);
+                    }).then(() => {
+                        return imap.listMessages('[Gmail]/B', '1:1', ['flags']);
+                    }).then((messages) => {
+                        expect(messages.length).to.equal(1);
+                        expect(messages[0].flags).to.deep.equal(['\\Seen']);
                     });
                 });
             });

--- a/test/integration/emailjs-imap-client-test.js
+++ b/test/integration/emailjs-imap-client-test.js
@@ -393,8 +393,8 @@
                     });
                 });
 
-                it('should send precheck commands in correct order on concurrent calls', () => {
-                    return Promise.all([
+                it('should send precheck commands in correct order on concurrent calls', (done) => {
+                    Promise.all([
                         imap.setFlags('[Gmail]/A', '1', ['\\Seen']),
                         imap.setFlags('[Gmail]/B', '1', ['\\Seen'])
                     ]).then(() => {
@@ -407,7 +407,7 @@
                     }).then((messages) => {
                         expect(messages.length).to.equal(1);
                         expect(messages[0].flags).to.deep.equal(['\\Seen']);
-                    });
+                    }).then(done).catch(done);
                 });
             });
         });

--- a/test/unit/emailjs-imap-client-test.js
+++ b/test/unit/emailjs-imap-client-test.js
@@ -134,9 +134,7 @@
 
         describe('#exec', () => {
             beforeEach(() => {
-                sinon.stub(br, 'breakIdle', () => {
-                    return Promise.resolve();
-                });
+                sinon.stub(br, 'breakIdle');
             });
 
             it('should send string command', (done) => {
@@ -194,9 +192,9 @@
                 sinon.stub(br.client.socket, 'send');
 
                 br._enteredIdle = 'IDLE';
-                br.breakIdle().then(() => {
-                    expect([].slice.call(new Uint8Array(br.client.socket.send.args[0][0]))).to.deep.equal([0x44, 0x4f, 0x4e, 0x45, 0x0d, 0x0a]);
-                }).then(done).catch(done);
+                br.breakIdle();
+                expect([].slice.call(new Uint8Array(br.client.socket.send.args[0][0]))).to.deep.equal([0x44, 0x4f, 0x4e, 0x45, 0x0d, 0x0a]);
+                done();
             });
         });
 


### PR DESCRIPTION
The issue is that the precheck mechanism depends on synchronous flow and breakIdle was breaking that flow when multiple functions with commands in their prechecks were called synchronously (instead of waiting for the previous function's promise to be resolved).

The error would present itself when synchronously calling e.g. setFlags for two different mailboxes, setFlags having selectMailbox as a precheck. So lets say the mailboxes are A and B so the order of the IMAP commands should be SELECT A, STORE, SELECT B, STORE, but ended up being STORE (A), SELECT B, STORE, SELECT A.

This error can be traced to promisifing work in 2015, specifically https://github.com/emailjs/emailjs-imap-client/commit/8ef7e21c3cc4c4e1507cc417248c71ed8f7112ea.