### PR TITLE
Fixed a concurrency issue where a selectMailbox precheck would not fire.

### DIFF
--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -288,6 +288,34 @@
     };
 
     /**
+     *
+     * @param commands
+     * @param ctx
+     * @returns {*}
+     */
+    Imap.prototype.getPreviouslyQueued = function(commands, ctx) {
+        const startIndex = this._clientQueue.indexOf(ctx) - 1;
+
+        // search backwards for the commands and return the first found
+        for (let i = startIndex; i >= 0; i--) {
+            if (isMatch(this._clientQueue[i])) {
+                return this._clientQueue[i];
+            }
+        }
+
+        // also check current command if no SELECT is queued
+        if (isMatch(this._currentCommand)) {
+            return this._currentCommand;
+        }
+
+        return false;
+
+        function isMatch(data) {
+            return data && data.request && commands.indexOf(data.request.command) >= 0;
+        }
+    };
+
+    /**
      * Send data to the TCP socket
      * Arms a timeout waiting for a response from the server.
      *

--- a/test/integration/emailjs-imap-client-test.js
+++ b/test/integration/emailjs-imap-client-test.js
@@ -46,7 +46,9 @@
                                     "Sent Mail": { "special-use": "\\Sent" },
                                     "Spam": { "special-use": "\\Junk" },
                                     "Starred": { "special-use": "\\Flagged" },
-                                    "Trash": { "special-use": "\\Trash" }
+                                    "Trash": { "special-use": "\\Trash" },
+                                    "A": { messages: [{}] },
+                                    "B": { messages: [{}] }
                                 }
                             }
                         }
@@ -388,6 +390,20 @@
                         return imap.selectMailbox('[Gmail]/Spam').then(() => {
                             done();
                         }).catch(done);
+                    });
+                });
+
+                it('should select correct mailboxes in prechecks on concurrent calls', () => {
+                    return imap.selectMailbox('[Gmail]/A').then(() => {
+                      return Promise.all([
+                        imap.selectMailbox('[Gmail]/B'),
+                        imap.setFlags('[Gmail]/A', '1', ['\\Seen'])
+                      ]);
+                    }).then(() => {
+                        return imap.listMessages('[Gmail]/A', '1:1', ['flags']);
+                    }).then((messages) => {
+                        expect(messages.length).to.equal(1);
+                        expect(messages[0].flags).to.deep.equal(['\\Seen']);
                     });
                 });
             });

--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -545,5 +545,99 @@
                 });
             });
         });
+
+        describe('#getPreviouslyQueued', () => {
+            const ctx = {};
+
+            it('should return undefined with empty queue and no current command', () => {
+                client._currentCommand = undefined;
+                client._clientQueue = [];
+
+                expect(testAndGetAttribute()).to.be.undefined;
+            });
+
+            it('should return undefined with empty queue and non-SELECT current command', () => {
+                client._currentCommand = createCommand('TEST');
+                client._clientQueue = [];
+
+                expect(testAndGetAttribute()).to.be.undefined;
+            });
+
+            it('should return current command with empty queue and SELECT current command', () => {
+                client._currentCommand = createCommand('SELECT', 'ATTR');
+                client._clientQueue = [];
+
+                expect(testAndGetAttribute()).to.equal('ATTR');
+            });
+
+            it('should return current command with non-SELECT commands in queue and SELECT current command', () => {
+                client._currentCommand = createCommand('SELECT', 'ATTR');
+                client._clientQueue = [
+                    createCommand('TEST01'),
+                    createCommand('TEST02')
+                ];
+
+                expect(testAndGetAttribute()).to.equal('ATTR');
+            });
+
+            it('should return last SELECT before ctx with multiple SELECT commands in queue (1)', () => {
+                client._currentCommand = createCommand('SELECT', 'ATTR01');
+                client._clientQueue = [
+                    createCommand('SELECT', 'ATTR'),
+                    createCommand('TEST'),
+                    ctx,
+                    createCommand('SELECT', 'ATTR03')
+                ];
+
+                expect(testAndGetAttribute()).to.equal('ATTR');
+
+            });
+
+            it('should return last SELECT before ctx with multiple SELECT commands in queue (2)', () => {
+                client._clientQueue = [
+                    createCommand('SELECT', 'ATTR02'),
+                    createCommand('SELECT', 'ATTR'),
+                    ctx,
+                    createCommand('SELECT', 'ATTR03')
+                ];
+
+                expect(testAndGetAttribute()).to.equal('ATTR');
+            });
+
+            it('should return last SELECT before ctx with multiple SELECT commands in queue (3)', () => {
+                client._clientQueue = [
+                    createCommand('SELECT', 'ATTR02'),
+                    createCommand('SELECT', 'ATTR'),
+                    createCommand('TEST'),
+                    ctx,
+                    createCommand('SELECT', 'ATTR03')
+                ];
+
+                expect(testAndGetAttribute()).to.equal('ATTR');
+            });
+
+            function testAndGetAttribute() {
+                const data = client.getPreviouslyQueued(['SELECT'], ctx);
+                if (data) {
+                    return data.request.attributes[0].value;
+                }
+            }
+
+            function createCommand(command, attribute) {
+                const attributes = [];
+                const data = {
+                    request: { command, attributes }
+                };
+
+                if (attribute) {
+                    data.request.attributes.push({
+                        type: 'STRING',
+                        value: attribute
+                    });
+                }
+
+                return data;
+            }
+        });
     });
 }));

--- a/test/unit/emailjs-imap-client-test.js
+++ b/test/unit/emailjs-imap-client-test.js
@@ -817,6 +817,40 @@
             });
         });
 
+        describe('#_shouldSelectMailbox', () => {
+            it('should return true when ctx is undefined', () => {
+                expect(br._shouldSelectMailbox('path')).to.be.true;
+            });
+
+            it('should return true when a different path is queued', () => {
+                sinon.stub(br.client, 'getPreviouslyQueued').returns({
+                    request: {
+                        command: 'SELECT',
+                        attributes: [{
+                            type: 'STRING',
+                            value: 'queued path'
+                        }]
+                    }
+                });
+
+                expect(br._shouldSelectMailbox('path', {})).to.be.true;
+            });
+
+            it('should return false when the same path is queued', () => {
+                sinon.stub(br.client, 'getPreviouslyQueued').returns({
+                    request: {
+                        command: 'SELECT',
+                        attributes: [{
+                            type: 'STRING',
+                            value: 'queued path'
+                        }]
+                    }
+                });
+
+                expect(br._shouldSelectMailbox('queued path', {})).to.be.false;
+            });
+       });
+
         describe('#selectMailbox', () => {
             beforeEach(() => {
                 sinon.stub(br, 'exec');


### PR DESCRIPTION
The _selectedMailbox check in the precheck functions does not take into account any potential SELECT commands on the queue or currently running, it only checks what is currently selected. So this here also checks the queue and anything currently running, looking for the last SELECT to run before the precheck's command should run.

See the integration test for a reproduction of the problem: box A is originally selected. Then a request to select B is sent, while that request is under way a setFlags in A is requested. A is still selected so the selectMailbox precheck does not fire. B gets selected and setFlags is then run there instead of A.