### PR TITLE
Fix lost callbacks on untagged responses

### DIFF
--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -475,8 +475,6 @@
         } else if (response.tag === '*' && command in this._globalAcceptUntagged) {
             // unexpected untagged response
             this._globalAcceptUntagged[command](response);
-            this._canSend = true;
-            this._sendRequest();
         } else if (response.tag === this._currentCommand.tag) {
             // tagged response
             if (this._currentCommand.payload && Object.keys(this._currentCommand.payload).length) {

--- a/test/integration/emailjs-imap-client-test.js
+++ b/test/integration/emailjs-imap-client-test.js
@@ -81,7 +81,7 @@
                 insecureServer.close(done);
             });
 
-            it('should use STARTTLS by default', () => {
+            it('should use STARTTLS by default', (done) => {
                 imap = new ImapClient('127.0.0.1', port, {
                     auth: {
                         user: "testuser",
@@ -91,14 +91,14 @@
                 });
                 imap.logLevel = imap.LOG_LEVEL_NONE;
 
-                return imap.connect().then(() => {
+                imap.connect().then(() => {
                     expect(imap.client.secureMode).to.be.true;
                 }).then(() => {
                     return imap.close();
-                });
+                }).then(() => done()).catch(done);
             });
 
-            it('should ignore STARTTLS', () => {
+            it('should ignore STARTTLS', (done) => {
                 imap = new ImapClient('127.0.0.1', port, {
                     auth: {
                         user: "testuser",
@@ -113,7 +113,7 @@
                     expect(imap.client.secureMode).to.be.false;
                 }).then(() => {
                     return imap.close();
-                });
+                }).then(() => done()).catch(done);
             });
 
             it('should fail connecting to non-STARTTLS host', (done) => {

--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -251,8 +251,8 @@
                     command: 'test'
                 });
 
-              expect(client._sendRequest.callCount).to.equal(0);
-              expect(client._globalAcceptUntagged.TEST.withArgs({
+                expect(client._sendRequest.callCount).to.equal(0);
+                expect(client._globalAcceptUntagged.TEST.withArgs({
                     tag: '*',
                     command: 'test'
                 }).callCount).to.equal(1);

--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -219,7 +219,6 @@
         describe('#_handleResponse', () => {
             it('should invoke global handler by default', () => {
                 sinon.stub(client, '_processResponse');
-                sinon.stub(client, '_sendRequest');
 
                 client._globalAcceptUntagged.TEST = () => {};
                 sinon.stub(client._globalAcceptUntagged, 'TEST');
@@ -230,7 +229,6 @@
                     command: 'test'
                 });
 
-                expect(client._sendRequest.callCount).to.equal(1);
                 expect(client._globalAcceptUntagged.TEST.withArgs({
                     tag: '*',
                     command: 'test'
@@ -239,7 +237,6 @@
 
             it('should invoke global handler if needed', () => {
                 sinon.stub(client, '_processResponse');
-                sinon.stub(client, '_sendRequest');
                 client._globalAcceptUntagged.TEST = () => {};
                 sinon.stub(client._globalAcceptUntagged, 'TEST');
 
@@ -251,7 +248,6 @@
                     command: 'test'
                 });
 
-                expect(client._sendRequest.callCount).to.equal(1);
                 expect(client._globalAcceptUntagged.TEST.withArgs({
                     tag: '*',
                     command: 'test'

--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -219,6 +219,7 @@
         describe('#_handleResponse', () => {
             it('should invoke global handler by default', () => {
                 sinon.stub(client, '_processResponse');
+                sinon.stub(client, '_sendRequest');
 
                 client._globalAcceptUntagged.TEST = () => {};
                 sinon.stub(client._globalAcceptUntagged, 'TEST');
@@ -229,6 +230,7 @@
                     command: 'test'
                 });
 
+                expect(client._sendRequest.callCount).to.equal(1);
                 expect(client._globalAcceptUntagged.TEST.withArgs({
                     tag: '*',
                     command: 'test'
@@ -239,6 +241,7 @@
                 sinon.stub(client, '_processResponse');
                 client._globalAcceptUntagged.TEST = () => {};
                 sinon.stub(client._globalAcceptUntagged, 'TEST');
+                sinon.stub(client, '_sendRequest');
 
                 client._currentCommand = {
                     payload: {}
@@ -248,7 +251,8 @@
                     command: 'test'
                 });
 
-                expect(client._globalAcceptUntagged.TEST.withArgs({
+              expect(client._sendRequest.callCount).to.equal(0);
+              expect(client._globalAcceptUntagged.TEST.withArgs({
                     tag: '*',
                     command: 'test'
                 }).callCount).to.equal(1);


### PR DESCRIPTION
Commands (and their callbacks) are getting lost when the client receives an untagged response from the server. The problem is that when the client receives an untagged response it calls _sendRequest which de-queues and overwrites the _currentCommand. Therefore, when the actual response for the overwritten command arrives it's command is lost and no callback is made and the promise left hanging.

The solution seems to be to not let untagged responses interfere with _currentCommand which is in line with the IMAP IETF standard, see https://tools.ietf.org/html/rfc3501#section-2.2 .