### PR TITLE
Optimize memory usage in _iterateIncomingBuffer()

### DIFF
--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -413,7 +413,11 @@
                 if (value >= 48 && value <= 57) { // value is a digit
                     this._literalRemainingBuffer.push(value);
                 } else {
-                    const text = String.fromCharCode(...this._literalRemainingBuffer);
+                    const chars = [];
+                    for (let asciiCode of this._literalRemainingBuffer) {
+                        chars.push(String.fromCharCode(asciiCode));
+                    }
+                    const text = chars.join('');
                     this._literalRemaining = Number(text) + 2; // +2 to cover the initial CRLF
                     readLiteral();
                     delete this._literalRemainingBuffer;

--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -413,11 +413,7 @@
                 if (value >= 48 && value <= 57) { // value is a digit
                     this._literalRemainingBuffer.push(value);
                 } else {
-                    const chars = [];
-                    for (let asciiCode of this._literalRemainingBuffer) {
-                        chars.push(String.fromCharCode(asciiCode));
-                    }
-                    const text = chars.join('');
+                    const text = this._literalRemainingBuffer.map((ascii) => String.fromCharCode(ascii)).join('');
                     this._literalRemaining = Number(text) + 2; // +2 to cover the initial CRLF
                     readLiteral();
                     delete this._literalRemainingBuffer;


### PR DESCRIPTION
This function is using strings to iterate through incoming data to construct commands. From a memory usage standpoint this is inefficient. The matcher produces an object that contains a copy of the entire matched string and the += operator as well as substr create a new string from its operands, producing a considerable amount of multiplication of memory allocation.

Continuously fetching messages of various sizes (I tested this using batches of 10-20 messages on my email account) would produce memory spikes of 100s of MBs and rapid GCing by V8.

So to get around this I've re-implemented this function using DataViews on the ASCII ArrayBuffers from _onData, only creating and returning a string at the very end of the process. This produced a much better memory graph on my timeline while taking slightly more time to run.

This PR requires a very close look at the code to make sure the functionality is accurately duplicated, so please do not be gentle. And any ideas as to how to optimize further are more than welcome!