### PR TITLE
Allow readOnly to be specified for SELECT vs EXAMINE in FETCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ client.selectMailbox('INBOX').then((mailbox) => { ... });
 
 ## List messages
 
-List messages with `listMessages(path, sequence, query[, options])`
+List messages with `listMessages(path, sequence, query[, options[, selectoptions]])`
 
 Where
 
@@ -312,6 +312,7 @@ Where
   * **options** is an optional options object
     * **byUid** if `true` executes `UID FETCH` instead of `FETCH`
     * **changedSince** is the modseq filter. Only messages with higher modseq value will be returned
+  * **selectoptions** is an optional object with options for SELECT
 
 Resolves with
 


### PR DESCRIPTION
Currently, options can be passed to select directly, but not when it is a precondition on listMessages, making readOnly unavailable in that case.  This adds an argument to ListMessages to be passed through.
Needs hoodiecrow to support read-only for appropriate integration testing