### PR TITLE
Log level in options

### DIFF
--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -66,7 +66,7 @@
 
         // Activate logging
         this.createLogger();
-        this.logLevel = this.LOG_LEVEL_ALL;
+        this.logLevel = options.logLevel ? options.logLevel : this.LOG_LEVEL_ALL;
     }
 
     /**


### PR DESCRIPTION
I know its not possible to use string verbose type if we do it this way, but at least we would be able to set logLevel by number in client options.