### PR TITLE
Fix issues #147 and hopefully #143

### DIFF
--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -295,10 +295,7 @@
             });
 
             function appendIncomingBuffer(content) {
-                const prevBuf = client._incomingBuffer;
-                client._incomingBuffer = new Uint8Array(prevBuf.length + content.length);
-                client._incomingBuffer.set(prevBuf);
-                client._incomingBuffer.set(mimefuncs.toTypedArray(content), prevBuf.length);
+                client._incomingBuffers.push(mimefuncs.toTypedArray(content));
             }
         });
 


### PR DESCRIPTION
Rewrite _iterateIncomingBuffer() to parse from the beginning of the buffer to the end in an attempt to make it easier to understand and to better cope with content handling while trying to chunk the server response into lines.

This addresses issue #147 for me. I don't know if it addresses the reported issue in #143, since I didn't report it, but I think it might. It does address the other similar issue that I reported in the comments of #143.