### PR TITLE
Values as uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Where
   * **options** is an optional options object
     * **byUid** if `true` executes `UID FETCH` instead of `FETCH`
     * **changedSince** is the modseq filter. Only messages with higher modseq value will be returned
+    * **valueAsString** LITERAL and STRING values are returned as strings rather than Uint8Array objects. Defaults to true.
 
 Resolves with
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "src/emailjs-imap-client",
   "dependencies": {
     "emailjs-addressparser": "^1.0.1",
-    "emailjs-imap-handler": "^2.0.0",
+    "emailjs-imap-handler": "^2.1.0",
     "emailjs-mime-codec": "^1.0.1",
     "emailjs-tcp-socket": "^1.0.1",
     "emailjs-utf7": "^3.0.1"

--- a/src/emailjs-imap-client-imap.js
+++ b/src/emailjs-imap-client-imap.js
@@ -560,7 +560,8 @@
 
             var response;
             try {
-                response = imapHandler.parser(command);
+               const valueAsString = this._currentCommand.request && this._currentCommand.request.valueAsString;
+               response = imapHandler.parser(command, { valueAsString });
                 this.logger.debug('S:', () => imapHandler.compiler(response, false, true));
             } catch (e) {
                 this.logger.error('Error parsing imap command!', response);

--- a/src/emailjs-imap-client.js
+++ b/src/emailjs-imap-client.js
@@ -1095,6 +1095,11 @@
                 value: sequence
             }]
         };
+
+        if (options.valueAsString !== undefined) {
+            command.valueAsString = options.valueAsString;
+        }
+
         var query = [];
 
         items.forEach((item) => {

--- a/test/unit/emailjs-imap-client-imap-test.js
+++ b/test/unit/emailjs-imap-client-imap-test.js
@@ -516,6 +516,27 @@
                     client._clientQueue[0].callback({});
                 }, 0);
             });
+
+            it('should store valueAsString option in the command', (done) => {
+                sinon.stub(client, '_sendRequest');
+
+                client._tagCounter = 100;
+                client._clientQueue = [];
+                client._canSend = false;
+
+                client.enqueueCommand({
+                    command: 'abc',
+                    valueAsString: false
+                }, ['def'], {
+                    t: 1
+                }).then(() => {
+                    expect(client._clientQueue[0].request.valueAsString).to.equal(false);
+                }).then(done).catch(done);
+
+                setTimeout(() => {
+                    client._clientQueue[0].callback({});
+                }, 0);
+            });
         });
 
         describe('#_sendRequest', () => {

--- a/test/unit/emailjs-imap-client-test.js
+++ b/test/unit/emailjs-imap-client-test.js
@@ -1447,6 +1447,21 @@
                     }]
                 });
             });
+
+            it('should build FETCH with the valueAsString option', () => {
+                expect(br._buildFETCHCommand('1:*', ['body[]'], {valueAsString: false})).to.deep.equal({
+                    command: 'FETCH',
+                    attributes: [{
+                        type: 'SEQUENCE',
+                        value: '1:*'
+                    }, {
+                        type: 'ATOM',
+                        value: 'BODY',
+                        section: []
+                    }],
+                    valueAsString: false
+                });
+            });
         });
 
         describe('#_parseFETCH', () => {


### PR DESCRIPTION
This brings the valueAsString option, allowing the user to get LITERAL and STRING values as Uint8Arrays rather than strings.