### PR TITLE
There is a possible race condition between Idle and closing a connection

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -159,7 +159,9 @@ Client.prototype.close = function (err) {
   this._changeState(this.STATE_LOGOUT)
   clearTimeout(this._idleTimeout)
   this.logger.debug('Closing connection...')
-  return this.client.close(err)
+  return this.client.close(err).then(() => {
+    clearTimeout(this._idleTimeout)
+  })
 }
 
 /**


### PR DESCRIPTION
Clear the idle timeout after that connection finishes closing
Fixes emailjs/emailjs-imap-client#160