### PR TITLE
Fixed attribute length condition in listMailBoxes

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -308,7 +308,7 @@ export default class Client {
     const list = pathOr([], ['payload', 'LIST'], listResponse)
     list.forEach(item => {
       const attr = propOr([], 'attributes', item)
-      if (!attr.length < 3) return
+      if (attr.length < 3) return
 
       const path = pathOr('', ['2', 'value'], attr)
       const delim = pathOr('/', ['1', 'value'], attr)
@@ -322,7 +322,7 @@ export default class Client {
     const lsub = pathOr([], ['payload', 'LSUB'], lsubResponse)
     lsub.forEach((item) => {
       const attr = propOr([], 'attributes', item)
-      if (!attr.length < 3) return
+      if (attr.length < 3) return
 
       const path = pathOr('', ['2', 'value'], attr)
       const delim = pathOr('/', ['1', 'value'], attr)


### PR DESCRIPTION
Fixes #167 

In ef1533662ad15f1dd5eb674f29fe0b5969533f1f a condition for the
number of attributes of the untagged response for the
listMailboxes command was changed from 'attr.length < 3' to
'!attr.length < 3', which is equivalent to 'attr.length >= 3'.
If this condition is true, the code will skip the mailbox. The RFC
specifies the response from LIST to be of the form:
`S: * LIST (\Noselect) "/" ~/Mail/foo`
Which has 3 parameters, so the condition will always evaluate to
true and skip the mailbox. The same applies to LSUB.

SEE: https://tools.ietf.org/html/rfc3501#section-7.2.2