### PR TITLE
Typo in closed socket error

### DIFF
--- a/src/imap.js
+++ b/src/imap.js
@@ -134,7 +134,7 @@ export default class Imap {
       } catch (E) { }
 
       // Connection closing unexpected is an error
-      this.socket.onclose = () => this._onError(new Error('Socket closed unexceptedly!'))
+      this.socket.onclose = () => this._onError(new Error('Socket closed unexpectedly!'))
       this.socket.ondata = (evt) => {
         try {
           this._onData(evt)


### PR DESCRIPTION
Fix typo in an error message when socket closes unexpectedly.