### PR TITLE
Include instructions for using as CommonJS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ npm install --save emailjs-imap-client
 ```
 ```javascript
 import ImapClient from 'emailjs-imap-client'
+
+// Use this instead for CommonJS modules (Node.js)
+var ImapClient = require('emailjs-imap-client').default
 ```
 
 ## API


### PR DESCRIPTION
I was in the process of creating an issue until I found https://github.com/emailjs/emailjs-imap-client/issues/182, which mentions that you have to add `.default` when using require as from vanilla Node.js. (without `.default` it would just throw `TypeError: ImapClient is not a constructor`)

I'm not used to the semantic of adding `.default` when translating an ES6 import to CommonJS, (I can't remember having to do it before) so I had troubles getting this to work with Node.js. How about adding this line to the README to make it easier for people not familiar with CommonJS module semantics?