### PR TITLE
Fix failed test for parseSearch

### DIFF
--- a/src/command-parser.js
+++ b/src/command-parser.js
@@ -446,6 +446,6 @@ export function parseSEARCH (response) {
     map(x => x.attributes || []),
     flatten,
     map(nr => Number(propOr(nr || 0, 'value', nr)) || 0),
-    sort((a, b) => a > b)
+    sort((a, b) => a - b)
   )(response)
 }


### PR DESCRIPTION
Sort algorithm was using a > b instead of a - b, failing to sort [5, 7, 6] to [5, 6, 7]