### PR TITLE
Upload and Copy now return the uids of new message instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,10 +602,10 @@ Where
   * **options** is an optional options object
     * **byUid** if `true` uses UID values instead of sequence numbers to define the range
 
-Resolves with an object which contains sequence sets of source and destination uids. Note that the ordering of the sets matter - the source uids map directly to the destination uids.
+Resolves with an object which contains uid sets of source and destination uids if the server supports [UIDPLUS](https://tools.ietf.org/html/rfc4315).
 
-  * **srcSeqSet** is the sequence set of the uids of the copied messages in the source mailbox
-  * **destSeqSet** is the sequence set of the new uids of the copied messages in the destination mailbox
+  * **srcSeqSet** is the uid set of the copied messages in the source mailbox
+  * **destSeqSet** is the uid set of the copied messages in the destination mailbox
 
 Command: [COPY](http://tools.ietf.org/html/rfc3501#section-6.4.7)
 
@@ -626,7 +626,7 @@ Where
   * **options** is an optional options object
     * **flags** is an array of flags you want to set on the uploaded message. Defaults to [\Seen]. (optional)
 
-Resolves with the new uid of the message in the destination folder.
+Resolves with the new uid of the message in the destination folder if the server supports [UIDPLUS](https://tools.ietf.org/html/rfc4315).
 
 Command: [COPY](http://tools.ietf.org/html/rfc3501#section-6.4.7)
 

--- a/README.md
+++ b/README.md
@@ -602,14 +602,38 @@ Where
   * **options** is an optional options object
     * **byUid** if `true` uses UID values instead of sequence numbers to define the range
 
-Resolves with a response text from the server. Not really useful, can be ignored.
+Resolves with an object which contains sequence sets of source and destination uids. Note that the ordering of the sets matter - the source uids map directly to the destination uids.
+
+  * **srcSeqSet** is the sequence set of the uids of the copied messages in the source mailbox
+  * **destSeqSet** is the sequence set of the new uids of the copied messages in the destination mailbox
 
 Command: [COPY](http://tools.ietf.org/html/rfc3501#section-6.4.7)
 
 ### Example
 
 ```javascript
-client.copyMessages('INBOX', '1:5', '[Gmail]/Trash').then(() => { ... });
+client.copyMessages('INBOX', '1:5', '[Gmail]/Trash').then(({srcSeqSet, destSeqSet}) => { ... });
+```
+
+## Upload a message
+
+Upload a message with `upload(destination, message, [, options])`
+
+Where
+
+  * **destination** is the destination folder path. Example: '[Gmail]/Trash'
+  * **message** is the message to be uploaded
+  * **options** is an optional options object
+    * **flags** is an array of flags you want to set on the uploaded message. Defaults to [\Seen]. (optional)
+
+Resolves with the new uid of the message in the destination folder.
+
+Command: [COPY](http://tools.ietf.org/html/rfc3501#section-6.4.7)
+
+### Example
+
+```javascript
+client.copyMessages('INBOX', '1:5', '[Gmail]/Trash').then(({srcSeqSet, destSeqSet}) => { ... });
 ```
 
 ## Move messages

--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ Where
 
 Resolves with the new uid of the message in the destination folder if the server supports [UIDPLUS](https://tools.ietf.org/html/rfc4315).
 
-Command: [COPY](http://tools.ietf.org/html/rfc3501#section-6.4.7)
+Command: [APPEND](https://tools.ietf.org/html/rfc3501#section-6.3.11)
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ Command: [COPY](http://tools.ietf.org/html/rfc3501#section-6.4.7)
 ### Example
 
 ```javascript
-client.copyMessages('INBOX', '1:5', '[Gmail]/Trash').then(({srcSeqSet, destSeqSet}) => { ... });
+client.upload('INBOX', message).then((uid) => { ... });
 ```
 
 ## Move messages

--- a/src/client-unit.js
+++ b/src/client-unit.js
@@ -783,8 +783,8 @@ describe('browserbox unit tests', () => {
         byUid: true
       }).then((response) => {
         expect(response).to.deep.equal({
-          sourceUids: '1:2',
-          destinationUids: '4,3'
+          srcSeqSet: '1:2',
+          destSeqSet: '4,3'
         })
         expect(br.exec.callCount).to.equal(1)
       })

--- a/src/client-unit.js
+++ b/src/client-unit.js
@@ -776,13 +776,16 @@ describe('browserbox unit tests', () => {
           value: '[Gmail]/Trash'
         }]
       }).returns(Promise.resolve({
-        humanReadable: 'abc'
+        copyuid: ['1', '1:2', '4,3']
       }))
 
       return br.copyMessages('INBOX', '1:2', '[Gmail]/Trash', {
         byUid: true
       }).then((response) => {
-        expect(response).to.equal('abc')
+        expect(response).to.deep.equal({
+          sourceUids: '1:2',
+          destinationUids: '4,3'
+        })
         expect(br.exec.callCount).to.equal(1)
       })
     })

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 import { map, pipe, union, zip, fromPairs, propOr, pathOr, flatten } from 'ramda'
 import { imapEncode, imapDecode } from 'emailjs-utf7'
 import {
-  parseASSIGN,
+  parseAPPEND,
   parseCOPY,
   parseNAMESPACE,
   parseSELECT,
@@ -500,7 +500,7 @@ export default class Client {
 
     this.logger.debug('Uploading message to', destination, '...')
     const response = await this.exec(command)
-    return parseASSIGN(response)
+    return parseAPPEND(response)
   }
 
   /**

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,8 @@
 import { map, pipe, union, zip, fromPairs, propOr, pathOr, flatten } from 'ramda'
 import { imapEncode, imapDecode } from 'emailjs-utf7'
 import {
+  parseASSIGN,
+  parseCOPY,
   parseNAMESPACE,
   parseSELECT,
   parseFETCH,
@@ -485,7 +487,7 @@ export default class Client {
    * @param {Array} options.flags Any flags you want to set on the uploaded message. Defaults to [\Seen]. (optional)
    * @returns {Promise} Promise with the array of matching seq. or uid numbers
    */
-  upload (destination, message, options = {}) {
+  async upload (destination, message, options = {}) {
     let flags = propOr(['\\Seen'], 'flags', options).map(value => ({ type: 'atom', value }))
     let command = {
       command: 'APPEND',
@@ -497,7 +499,8 @@ export default class Client {
     }
 
     this.logger.debug('Uploading message to', destination, '...')
-    return this.exec(command)
+    const response = await this.exec(command)
+    return parseASSIGN(response)
   }
 
   /**
@@ -547,7 +550,7 @@ export default class Client {
    */
   async copyMessages (path, sequence, destination, options = {}) {
     this.logger.debug('Copying messages', sequence, 'from', path, 'to', destination, '...')
-    const { humanReadable } = await this.exec({
+    const response = await this.exec({
       command: options.byUid ? 'UID COPY' : 'COPY',
       attributes: [
         { type: 'sequence', value: sequence },
@@ -556,7 +559,7 @@ export default class Client {
     }, null, {
       precheck: (ctx) => this._shouldSelectMailbox(path, ctx) ? this.selectMailbox(path, { ctx }) : Promise.resolve()
     })
-    return humanReadable || 'COPY completed'
+    return parseCOPY(response)
   }
 
   /**

--- a/src/command-parser-unit.js
+++ b/src/command-parser-unit.js
@@ -498,7 +498,7 @@ describe('parseCOPY', () => {
 })
 
 describe('parseAPPEND', () => {
-  it('should parse ASSIGN response', () => {
+  it('should parse APPEND response', () => {
     expect(parseAPPEND({
       appenduid: ['1', '3']
     })).to.equal('3')

--- a/src/command-parser-unit.js
+++ b/src/command-parser-unit.js
@@ -483,8 +483,8 @@ describe('parseCOPY', () => {
     expect(parseCOPY({
       copyuid: ['1', '1:3', '3,4,2']
     })).to.deep.equal({
-      sourceUids: '1:3',
-      destinationUids: '3,4,2'
+      srcSeqSet: '1:3',
+      destSeqSet: '3,4,2'
     })
   })
 })

--- a/src/command-parser-unit.js
+++ b/src/command-parser-unit.js
@@ -487,6 +487,14 @@ describe('parseCOPY', () => {
       destSeqSet: '3,4,2'
     })
   })
+
+  it('should return undefined when response does not contain copyuid', () => {
+    expect(parseCOPY({})).to.equal(undefined)
+  })
+
+  it('should return undefined when response is not defined', () => {
+    expect(parseCOPY()).to.equal(undefined)
+  })
 })
 
 describe('parseAPPEND', () => {
@@ -494,5 +502,13 @@ describe('parseAPPEND', () => {
     expect(parseAPPEND({
       appenduid: ['1', '3']
     })).to.equal('3')
+  })
+
+  it('should return undefined when response does not contain copyuid', () => {
+    expect(parseAPPEND({})).to.equal(undefined)
+  })
+
+  it('should return undefined when response is not defined', () => {
+    expect(parseAPPEND()).to.equal(undefined)
   })
 })

--- a/src/command-parser-unit.js
+++ b/src/command-parser-unit.js
@@ -3,6 +3,8 @@
 
 import { parser } from 'emailjs-imap-handler'
 import {
+  parseASSIGN,
+  parseCOPY,
   parseSEARCH,
   parseNAMESPACE,
   parseENVELOPE,
@@ -473,5 +475,24 @@ describe('parseSEARCH', () => {
         }]
       }
     })).to.deep.equal([])
+  })
+})
+
+describe('parseCOPY', () => {
+  it('should parse COPY response', () => {
+    expect(parseCOPY({
+      copyuid: ['1', '1:3', '3,4,2']
+    })).to.deep.equal({
+      sourceUids: '1:3',
+      destinationUids: '3,4,2'
+    })
+  })
+})
+
+describe('parseASSIGN', () => {
+  it('should parse ASSIGN response', () => {
+    expect(parseASSIGN({
+      appenduid: ['1', '3']
+    })).to.equal('3')
   })
 })

--- a/src/command-parser-unit.js
+++ b/src/command-parser-unit.js
@@ -3,7 +3,7 @@
 
 import { parser } from 'emailjs-imap-handler'
 import {
-  parseASSIGN,
+  parseAPPEND,
   parseCOPY,
   parseSEARCH,
   parseNAMESPACE,
@@ -489,9 +489,9 @@ describe('parseCOPY', () => {
   })
 })
 
-describe('parseASSIGN', () => {
+describe('parseAPPEND', () => {
   it('should parse ASSIGN response', () => {
-    expect(parseASSIGN({
+    expect(parseAPPEND({
       appenduid: ['1', '3']
     })).to.equal('3')
   })

--- a/src/command-parser.js
+++ b/src/command-parser.js
@@ -453,16 +453,16 @@ export function parseSEARCH (response) {
 /**
  * Parses COPY and UID COPY response.
  * @param {Object} response
- * @returns {{destinationUids: string, sourceUids: string}} Source and
+ * @returns {{destSeqSet: string, srcSeqSet: string}} Source and
  * destination uid sequence sets.
  */
 export function parseCOPY (response) {
-  const value = { sourceUids: '', destinationUids: '' }
+  const value = { srcSeqSet: '', destSeqSet: '' }
   const copyuid = response && response.copyuid
 
   if (copyuid) {
-    value.sourceUids = copyuid[1]
-    value.destinationUids = copyuid[2]
+    value.srcSeqSet = copyuid[1]
+    value.destSeqSet = copyuid[2]
   }
 
   return value

--- a/src/command-parser.js
+++ b/src/command-parser.js
@@ -499,26 +499,26 @@ export function parseSEARCH (response) {
 
 /**
  * Parses COPY and UID COPY response.
+ * https://tools.ietf.org/html/rfc4315
  * @param {Object} response
  * @returns {{destSeqSet: string, srcSeqSet: string}} Source and
- * destination uid sequence sets.
+ * destination uid sets if available, undefined if not.
  */
 export function parseCOPY (response) {
-  const value = { srcSeqSet: '', destSeqSet: '' }
   const copyuid = response && response.copyuid
-
   if (copyuid) {
-    value.srcSeqSet = copyuid[1]
-    value.destSeqSet = copyuid[2]
+    return {
+      srcSeqSet: copyuid[1],
+      destSeqSet: copyuid[2]
+    }
   }
-
-  return value
 }
 
 /**
  * Parses APPEND (upload) response.
+ * https://tools.ietf.org/html/rfc4315
  * @param {Object} response
- * @returns {String} The uid assigned to the uploaded message.
+ * @returns {String} The uid assigned to the uploaded message if available.
  */
 export function parseAPPEND (response) {
   return response && response.appenduid && response.appenduid[1]

--- a/src/command-parser.js
+++ b/src/command-parser.js
@@ -520,6 +520,6 @@ export function parseCOPY (response) {
  * @param {Object} response
  * @returns {String} The uid assigned to the uploaded message.
  */
-export function parseASSIGN (response) {
+export function parseAPPEND (response) {
   return response && response.appenduid && response.appenduid[1]
 }

--- a/src/command-parser.js
+++ b/src/command-parser.js
@@ -449,3 +449,30 @@ export function parseSEARCH (response) {
     sort((a, b) => a > b)
   )(response)
 }
+
+/**
+ * Parses COPY and UID COPY response.
+ * @param {Object} response
+ * @returns {{destinationUids: string, sourceUids: string}} Source and
+ * destination uid sequence sets.
+ */
+export function parseCOPY (response) {
+  const value = {sourceUids: "", destinationUids: ""}
+  const copyuid = response && response.copyuid
+
+  if (copyuid) {
+    value.sourceUids = copyuid[1]
+    value.destinationUids = copyuid[2]
+  }
+
+  return value
+}
+
+/**
+ * Parses APPEND (upload) response.
+ * @param {Object} response
+ * @returns {String} The uid assigned to the uploaded message.
+ */
+export function parseASSIGN (response) {
+  return response && response.appenduid && response.appenduid[1]
+}

--- a/src/command-parser.js
+++ b/src/command-parser.js
@@ -457,7 +457,7 @@ export function parseSEARCH (response) {
  * destination uid sequence sets.
  */
 export function parseCOPY (response) {
-  const value = {sourceUids: "", destinationUids: ""}
+  const value = { sourceUids: '', destinationUids: '' }
   const copyuid = response && response.copyuid
 
   if (copyuid) {


### PR DESCRIPTION
The response object returned from exec contains the uids but the functions were not exposing them. They are necessary to be able to create client side imap data entries without having to do selectMailbox+listMessages.