### PR TITLE
Add option to disable idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Where
     * **ignoreTLS** – if set to true, *never uses STARTTLS before authentication* even if the host advertises support for it
     * **requireTLS** – if set to true, *always uses STARTTLS before authentication* even if the host does not advertise it. If STARTTLS fails, do not try to authenticate the user
     * **enableCompression** - if set to true then use IMAP COMPRESS extension (rfc4978) if the server supports it (Gmail does). All data sent and received in this case is compressed with *deflate*
+    * **idle** - (optional) if set to false, idle will not be entered. Defaults to true. Please note, that if idle is set to false `client.onupdate` will not be triggered automatically anymore.
 
 Default STARTTLS support is opportunistic – if the server advertises STARTTLS capability, the client tries to use it. If STARTTLS is not advertised, the clients sends passwords in the plain. You can use `ignoreTLS` and `requireTLS` to change this behavior by explicitly enabling or disabling STARTTLS usage.
 

--- a/src/client.js
+++ b/src/client.js
@@ -73,6 +73,7 @@ export default class Client {
     this._capability = [] // List of extensions the server supports
     this._selectedMailbox = false // Selected mailbox
     this._enteredIdle = false
+    this._useIdle = propOr(true, 'idle', options)
     this._idleTimeout = false
     this._enableCompression = !!options.enableCompression
     this._auth = options.auth
@@ -715,7 +716,7 @@ export default class Client {
       return
     }
     const supportsIdle = this._capability.indexOf('IDLE') >= 0
-    this._enteredIdle = supportsIdle && this._selectedMailbox ? 'IDLE' : 'NOOP'
+    this._enteredIdle = supportsIdle && this._selectedMailbox && this._useIdle ? 'IDLE' : 'NOOP'
     this.logger.debug('Entering idle with ' + this._enteredIdle)
 
     if (this._enteredIdle === 'NOOP') {


### PR DESCRIPTION
I don't know if anyone will ever have a look at this, but I just thought to give it a try. 

This adds a new option `idle` which defaults to true and which can be used to prevent the connection from idling. 