### PR TITLE
Invalid SEARCH response should return undefined instead of an

### DIFF
--- a/src/command-parser-unit.js
+++ b/src/command-parser-unit.js
@@ -477,8 +477,8 @@ describe('parseSEARCH', () => {
     })).to.deep.equal([])
   })
 
-  it('should return undefined when response is not defined', () => {
-    expect(parseSEARCH()).to.equal(undefined)
+  it('should throw error when response is not defined', () => {
+    expect(() => parseSEARCH()).throws(Error, 'parseSEARCH')
   })
 })
 

--- a/src/command-parser-unit.js
+++ b/src/command-parser-unit.js
@@ -476,6 +476,10 @@ describe('parseSEARCH', () => {
       }
     })).to.deep.equal([])
   })
+
+  it('should return undefined when response is not defined', () => {
+    expect(parseSEARCH()).to.equal(undefined)
+  })
 })
 
 describe('parseCOPY', () => {

--- a/src/command-parser.js
+++ b/src/command-parser.js
@@ -474,14 +474,19 @@ function binSearch (haystack, needle, comparator = (a, b) => a - b) {
  * and compiles these into a sorted array.
  *
  * @param {Object} response
- * @return {Array} Sorted Seq./UID number list or undefined if response is not valid
+ * @return {Array} Sorted Seq./UID number list
  */
 export function parseSEARCH (response) {
-  if (!response || !response.payload || !response.payload.SEARCH || !response.payload.SEARCH.length) {
-    return
+  const list = []
+
+  if (!response) {
+    throw new Error('parseSEARCH can not parse undefined response')
   }
 
-  const list = []
+  if (!response.payload || !response.payload.SEARCH || !response.payload.SEARCH.length) {
+    return list
+  }
+
   response.payload.SEARCH.forEach(result =>
     (result.attributes || []).forEach(nr => {
       nr = Number((nr && nr.value) || nr) || 0

--- a/src/command-parser.js
+++ b/src/command-parser.js
@@ -474,16 +474,14 @@ function binSearch (haystack, needle, comparator = (a, b) => a - b) {
  * and compiles these into a sorted array.
  *
  * @param {Object} response
- * @return {Object} Message object
- * @param {Array} Sorted Seq./UID number list
+ * @return {Array} Sorted Seq./UID number list or undefined if response is not valid
  */
 export function parseSEARCH (response) {
-  const list = []
-
   if (!response || !response.payload || !response.payload.SEARCH || !response.payload.SEARCH.length) {
-    return list
+    return
   }
 
+  const list = []
   response.payload.SEARCH.forEach(result =>
     (result.attributes || []).forEach(nr => {
       nr = Number((nr && nr.value) || nr) || 0


### PR DESCRIPTION
empty list. Empty list should mean that nothing was found.

According to my research, the SEARCH array in the response will
always be an array of length 1 or higher. For a search that returns
no messages it is the "attributes" attribute of objects in the
SEARCH array that will contain the values. And if nothing was found
then the "attributes" attribute is missing.

It is bad for our client (Vivaldi) to receive an empty list as a,
seemingly, valid response because that means that we mark all the
message as having been removed from the server. They become
internal messages and only visible in the Trash view.