### PR TITLE
Don't ignore errors from updateId (ID commands) while connecting.

### DIFF
--- a/src/client-unit.js
+++ b/src/client-unit.js
@@ -92,6 +92,45 @@ describe('browserbox unit tests', () => {
       })
     })
 
+    it('should connect even though ID command is BAD', () => {
+      var idError = new Error()
+      idError.command = 'BAD'
+
+      br.client.connect.returns(Promise.resolve())
+      br.updateCapability.returns(Promise.resolve())
+      br.upgradeConnection.returns(Promise.resolve())
+      br.updateId.throws(idError)
+      br.login.returns(Promise.resolve())
+      br.compressConnection.returns(Promise.resolve())
+
+      setTimeout(() => br.client.onready(), 0)
+      return br.connect().then(() => {
+        expect(br.client.connect.calledOnce).to.be.true
+        expect(br.updateCapability.calledOnce).to.be.true
+        expect(br.upgradeConnection.calledOnce).to.be.true
+        expect(br.updateId.calledOnce).to.be.true
+        expect(br.login.calledOnce).to.be.true
+        expect(br.compressConnection.calledOnce).to.be.true
+      })
+    })
+
+    it('should fail on non-BAD error during ID command', () => {
+      br.client.connect.returns(Promise.resolve())
+      br.updateCapability.returns(Promise.resolve())
+      br.upgradeConnection.returns(Promise.resolve())
+      br.updateId.throws(new Error())
+
+      setTimeout(() => br.client.onready(), 0)
+      return br.connect().catch(() => {
+        expect(br.client.connect.calledOnce).to.be.true
+        expect(br.updateCapability.calledOnce).to.be.true
+        expect(br.upgradeConnection.calledOnce).to.be.true
+        expect(br.updateId.calledOnce).to.be.true
+        expect(br.login.called).to.be.false
+        expect(br.compressConnection.called).to.be.false
+      })
+    })
+
     it('should fail to login', (done) => {
       br.client.connect.returns(Promise.resolve())
       br.updateCapability.returns(Promise.resolve())

--- a/src/client.js
+++ b/src/client.js
@@ -127,12 +127,7 @@ export default class Client {
     try {
       await this.openConnection()
       await this.upgradeConnection()
-      try {
-        await this.updateId(this._clientId)
-      } catch (err) {
-        this.logger.warn('Failed to update server id!', err.message)
-      }
-
+      await this.updateId(this._clientId)
       await this.login(this._auth)
       await this.compressConnection()
       this.logger.debug('Connection established, ready to roll!')

--- a/src/imap-unit.js
+++ b/src/imap-unit.js
@@ -456,6 +456,7 @@ describe('browserbox imap unit tests', () => {
         t: 1
       }).catch((err) => {
         expect(err).to.exist
+        expect(err.command).to.equal('NO')
       })
     })
 

--- a/src/imap.js
+++ b/src/imap.js
@@ -265,12 +265,16 @@ export default class Imap {
         callback: (response) => {
           if (this.isError(response)) {
             return reject(response)
-          } else if (['NO', 'BAD'].indexOf(propOr('', 'command', response).toUpperCase().trim()) >= 0) {
-            var error = new Error(response.humanReadable || 'Error')
-            if (response.code) {
-              error.code = response.code
+          } else {
+            const command = propOr('', 'command', response).toUpperCase().trim()
+            if (['NO', 'BAD'].includes(command)) {
+              var error = new Error(response.humanReadable || 'Error')
+              error.command = command
+              if (response.code) {
+                error.code = response.code
+              }
+              return reject(error)
             }
-            return reject(error)
           }
 
           resolve(response)


### PR DESCRIPTION
We have been running into socket errors that get ignored which puts the connection in an unusable state, leaving it with a hanging promise/await which breaks our connection management code.

I wonder if that catch was put there for the case where the server returns BAD because it doesn't support the ID command, but there is actually a check for that at the beginning of updateId(). In any case this catch wouldn't just ignore BAD responses but also any and all errors which it shouldn't do.