### PR TITLE
Fix min timeout

### DIFF
--- a/dist/imap.js
+++ b/dist/imap.js
@@ -359,7 +359,8 @@ class Imap {
 
   send(str) {
     const buffer = (0, _common.toTypedArray)(str).buffer;
-    const timeout = this.timeoutSocketLowerBound + Math.floor(buffer.byteLength * this.timeoutSocketMultiplier);
+    let timeout = this.timeoutSocketLowerBound + Math.floor(buffer.byteLength * this.timeoutSocketMultiplier);
+    timeout = timeout < this.timeoutSocketLowerBound ? this.timeoutSocketLowerBound : timeout;
     clearTimeout(this._socketTimeoutTimer); // clear pending timeouts
 
     this._socketTimeoutTimer = setTimeout(() => this._onError(new Error(' Socket timed out!')), timeout); // arm the next timeout

--- a/src/imap.js
+++ b/src/imap.js
@@ -846,7 +846,8 @@ export default class Imap {
 
   _resetSocketTimeout (byteLength) {
     clearTimeout(this._socketTimeoutTimer)
-    const timeout = this.timeoutSocketLowerBound + Math.floor((byteLength || 4096) * this.timeoutSocketMultiplier) // max packet size is 4096 bytes
+    let timeout = this.timeoutSocketLowerBound + Math.floor((byteLength || 4096) * this.timeoutSocketMultiplier) // max packet size is 4096 bytes
+    timeout = timeout < this.timeoutSocketLowerBound ? this.timeoutSocketLowerBound : timeout
     this._socketTimeoutTimer = setTimeout(() => this._onError(new Error(' Socket timed out!')), timeout)
   }
 }


### PR DESCRIPTION
Fixing minimum timeout that often lead to socket timeout before receiving the response. From now on, minimum timeout is equal to this.timeoutSocketLowerBound.