### PR TITLE
Socket closing is not an error.

### DIFF
--- a/src/imap-unit.js
+++ b/src/imap-unit.js
@@ -99,10 +99,12 @@ describe('browserbox imap unit tests', () => {
   })
 
   describe('#socket.onclose', () => {
-    it('should close the client', () => {
+    it('should close the client and emit error', () => {
       sinon.stub(client, 'close')
+      sinon.stub(client, '_onError')
       client.socket.onclose()
       expect(client.close.calledOnce).to.be.true
+      expect(client._onError.calledOnce).to.be.true
     })
   })
 

--- a/src/imap-unit.js
+++ b/src/imap-unit.js
@@ -99,12 +99,10 @@ describe('browserbox imap unit tests', () => {
   })
 
   describe('#socket.onclose', () => {
-    it('should emit error ', (done) => {
+    it('should close the client', () => {
+      sinon.stub(client, 'close')
       client.socket.onclose()
-
-      client.onerror = () => {
-        done()
-      }
+      expect(client.close.calledOnce).to.be.true
     })
   })
 

--- a/src/imap.js
+++ b/src/imap.js
@@ -133,9 +133,12 @@ export default class Imap {
         this.socket.oncert = (cert) => { this.oncert && this.oncert(cert) }
       } catch (E) { }
 
-      // Socket closing - let's close the client
-      this.socket.onclose = () => this.close()
-
+      // Connection closing unexpected is an error
+      this.socket.onclose = () => {
+        const error = new Error('Socket closed unexpectedly!')
+        this.close(error)
+        this._onError(error)
+      }
       this.socket.ondata = (evt) => {
         try {
           this._onData(evt)
@@ -380,7 +383,10 @@ export default class Imap {
       error = new Error((evt && evt.data && evt.data.message) || evt.data || evt || 'Error')
     }
 
-    this.logger.error(error)
+    // only log here if no onerror handler is supplied
+    if (!this.onerror) {
+      this.logger.error(error)
+    }
 
     // always call onerror callback, no matter if close() succeeds or fails
     this.close(error).then(() => {

--- a/src/imap.js
+++ b/src/imap.js
@@ -133,8 +133,9 @@ export default class Imap {
         this.socket.oncert = (cert) => { this.oncert && this.oncert(cert) }
       } catch (E) { }
 
-      // Connection closing unexpected is an error
-      this.socket.onclose = () => this._onError(new Error('Socket closed unexpectedly!'))
+      // Socket closing - let's close the client
+      this.socket.onclose = () => this.close()
+
       this.socket.ondata = (evt) => {
         try {
           this._onData(evt)


### PR DESCRIPTION
Socket will close when network goes down e.g. when machine is being suspended/hibernated. This should not be treated as an error. Rather, the imap-client should wrap up and close also.