### PR TITLE
Catch and log errors that occur when doing IDLE or NOOP requests.

### DIFF
--- a/src/client-unit.js
+++ b/src/client-unit.js
@@ -219,6 +219,7 @@ describe('browserbox unit tests', () => {
         expect(command).to.equal('NOOP')
 
         done()
+        return Promise.resolve()
       })
 
       br._capability = []
@@ -232,6 +233,7 @@ describe('browserbox unit tests', () => {
         expect(command).to.equal('NOOP')
 
         done()
+        return Promise.resolve()
       })
 
       br._capability = ['IDLE']
@@ -241,7 +243,7 @@ describe('browserbox unit tests', () => {
     })
 
     it('should break IDLE after timeout', (done) => {
-      sinon.stub(br.client, 'enqueueCommand')
+      sinon.stub(br.client, 'enqueueCommand').returns(Promise.resolve())
       sinon.stub(br.client.socket, 'send').callsFake((payload) => {
         expect(br.client.enqueueCommand.args[0][0].command).to.equal('IDLE')
         expect([].slice.call(new Uint8Array(payload))).to.deep.equal([0x44, 0x4f, 0x4e, 0x45, 0x0d, 0x0a])

--- a/src/client.js
+++ b/src/client.js
@@ -761,7 +761,7 @@ export default class Client {
    * IDLE details:
    *   https://tools.ietf.org/html/rfc2177
    */
-  async enterIdle () {
+  enterIdle () {
     if (this._enteredIdle) {
       return
     }
@@ -770,22 +770,14 @@ export default class Client {
     this.logger.debug('Entering idle with ' + this._enteredIdle)
 
     if (this._enteredIdle === 'NOOP') {
-      this._idleTimeout = setTimeout(async () => {
+      this._idleTimeout = setTimeout(() => {
         this.logger.debug('Sending NOOP')
-        try {
-          await this.exec('NOOP')
-        } catch (e) {
-          this.logger.error('Could not idle (NOOP)', e)
-        }
+        this.exec('NOOP').catch(e => this.logger.error('Could not idle (NOOP)', e))
       }, this.timeoutNoop)
     } else if (this._enteredIdle === 'IDLE') {
-      try {
-        await this.client.enqueueCommand({
-          command: 'IDLE'
-        })
-      } catch (e) {
-        this.logger.error('Could not idle (IDLE)', e)
-      }
+      this.client.enqueueCommand({
+        command: 'IDLE'
+      }).catch(e => this.logger.error('Could not idle (IDLE)', e))
       this._idleTimeout = setTimeout(() => {
         this.client.send('DONE\r\n')
         this._enteredIdle = false

--- a/src/client.js
+++ b/src/client.js
@@ -761,7 +761,7 @@ export default class Client {
    * IDLE details:
    *   https://tools.ietf.org/html/rfc2177
    */
-  enterIdle () {
+  async enterIdle () {
     if (this._enteredIdle) {
       return
     }
@@ -770,14 +770,22 @@ export default class Client {
     this.logger.debug('Entering idle with ' + this._enteredIdle)
 
     if (this._enteredIdle === 'NOOP') {
-      this._idleTimeout = setTimeout(() => {
+      this._idleTimeout = setTimeout(async () => {
         this.logger.debug('Sending NOOP')
-        this.exec('NOOP')
+        try {
+          await this.exec('NOOP')
+        } catch (e) {
+          this.logger.error('Could not idle (NOOP)', e)
+        }
       }, this.timeoutNoop)
     } else if (this._enteredIdle === 'IDLE') {
-      this.client.enqueueCommand({
-        command: 'IDLE'
-      })
+      try {
+        await this.client.enqueueCommand({
+          command: 'IDLE'
+        })
+      } catch (e) {
+        this.logger.error('Could not idle (IDLE)', e)
+      }
       this._idleTimeout = setTimeout(() => {
         this.client.send('DONE\r\n')
         this._enteredIdle = false


### PR DESCRIPTION
This prevents uncaught errors from bubbling up and properly logs them instead.