### PR TITLE
Recognize boxes named Archive(s) as special boxes

### DIFF
--- a/src/special-use-unit.js
+++ b/src/special-use-unit.js
@@ -39,4 +39,13 @@ describe('checkSpecialUse', () => {
       name: 'Praht'
     })).to.equal('\\All')
   })
+
+  it('should return an Archive flag on finding box named Archive or Archives', () => {
+    expect(checkSpecialUse({
+      name: 'Archive'
+    })).to.equal('\\Archive')
+    expect(checkSpecialUse({
+      name: 'Archives'
+    })).to.equal('\\Archive')
+  })
 })

--- a/src/special-use.js
+++ b/src/special-use.js
@@ -39,7 +39,10 @@ const SPECIAL_USE_BOXES = {
     'սևագրեր', 'טיוטות', 'مسودات', 'مسودات', 'موسودې', 'پیش نویسها', 'ڈرافٹ/', 'ड्राफ़्ट', 'प्रारूप', 'খসড়া', 'খসড়া', 'ড্ৰাফ্ট', 'ਡ੍ਰਾਫਟ', 'ડ્રાફ્ટસ',
     'ଡ୍ରାଫ୍ଟ', 'வரைவுகள்', 'చిత్తు ప్రతులు', 'ಕರಡುಗಳು', 'കരടുകള്‍', 'කෙටුම් පත්', 'ฉบับร่าง', 'მონახაზები', 'ረቂቆች', 'សារព្រាង', '下書き', '草稿',
     '草稿', '草稿', '임시 보관함'
-  ]
+  ],
+  // The \Archive flag is rarely used by major email providers so we also check the path.
+  // Thunderbird names them Archives instead of Archive.
+  '\\Archive': ['archive', 'archives']
 }
 const SPECIAL_USE_BOX_FLAGS = Object.keys(SPECIAL_USE_BOXES)
 


### PR DESCRIPTION
This library is already accounting for special-use boxes of type \Archive. It was missing to match that also on the names. Some server have it singular 'Archive' while others have it plural 'Archives'. Other boxes have a long list of names in different languages. That is not done here but could be a future consideration. I see that the other boxes don't support Icelandic translations.